### PR TITLE
CASMTRIAGE-1871: Clarify help message for cfs session target-groups (1.0)

### DIFF
--- a/cray/modules/cfs/cli.py
+++ b/cray/modules/cfs/cli.py
@@ -164,10 +164,10 @@ def setup_sessions_create(cfs_cli):
     # and member lists. `option` acts as a decorator here.
     option('--'+GROUPS_PAYLOAD, nargs=2, type=click.Tuple([str, str]), multiple=True,
            payload_name=GROUPS_PAYLOAD, callback=_targets_callback(_opt_callback),
-           metavar='GROUPNAME MEMBER1[, MEMBER2, MEMBER3, ...]',
-           help="Group members for the inventory. When the inventory definition is "
-                "'image', only one group with a single IMS image id should be "
-                "specified. Multiple groups can be specified.")(command)
+           metavar='GROUPNAME MEMBER1[,MEMBER2,MEMBER3,...]',
+           help="Group members for the inventory. "
+                "Multiple groups can be specified by providing this parameter more than once."
+                "")(command)
     option('--tags', callback=_opt_callback, required=False, type=str, metavar='TEXT',
            help="User defined tags.  A comma separated list of key=value")(command)
 


### PR DESCRIPTION
### Summary and Scope

Image customization for the 1.5 deploy on Ego needed an image customization that included both the Application and Application_UAN roles.  Rather than running two separate sessions (building an Application image and then building on top of that) they wanted to run a single image customization that applied both roles.  This was already supported, but unclear from the help message if this was the case or how to use this feature.  This clarifies that message.

### Issues and Related PRs

* Resolves CASMTRIAGE-1871

### Testing

Tested on:

* Ego

The cli support for this feature was confirmed on Ego, this PR only affects the help message.
### Risks and Mitigations

None