### PR TITLE
Fix lint issues in build

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -144,7 +144,8 @@ disable=print-statement,
         useless-object-inheritance,
         superfluous-parens,
         fixme,
-        consider-using-f-string
+        consider-using-f-string,
+        global-variable-not-assigned
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
Two new lint errors have cropped up, one about using f-strings instead of old-style format strings and one about using the `global` keyword to make a variable global in contexts where the variable is not actually modified.  We use standard format strings everywhere in the CLI and it is not really a serious problem, so I am disabling this.  There are a couple of places where we use `global` unnecessarily in the code, and, since this does not really seem to be a big concern (there is the chance of an unwanted side effect, but that would never be detected by the lint error anyway if it crept in) I am disabling that error as well.