### PR TITLE
CASMCMS-7876: Update BOS cli for v2

### DIFF
--- a/cray/generator.py
+++ b/cray/generator.py
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 """ Generates CLI commands from parsed swagger file
 
 MIT License
@@ -53,9 +76,11 @@ def api(data, callback, base=''):
     """ Decorator that will send endpoint data into commands """
 
     def tags_decorator(func):  # pylint: disable=missing-docstring
-        def func_wrapper(*args, **kwargs):  # pylint: disable=missing-docstring
+        def func_wrapper(*args, data_handler=None, **kwargs):  # pylint: disable=missing-docstring
             kwargs['base'] = base
             args = _parse_data(data, **kwargs)
+            if data_handler:
+                args=data_handler(args)
             opts = args[-1]
             opts['callback'] = callback
             return func(*args[:-1], **opts)

--- a/cray/modules/bos/cli.py
+++ b/cray/modules/bos/cli.py
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 """bos
 
 MIT License
@@ -50,31 +73,104 @@ else:
 # Add --file parameter for specifying session template data
 def create_templates_shim(func):
     """ Callback function to custom create our own payload """
-    def _decorator(file, name, **kwargs):
+    def _decorator(file, **kwargs):
         if not file.get('value'):
-            return func(name=name, **kwargs)
+            return func(**kwargs)
         with open(file["value"], 'r', encoding='utf-8') as f:
             data = json.loads(f.read())
         payload = data
-        if name:
-            payload['name'] = name['value']
+        if 'name' in kwargs:
+            payload['name'] = kwargs['name']['value']
+            del kwargs['name']
         # Hack to tell the CLI we are passing our own payload; don't generate
         kwargs[FROM_FILE_TAG] = {"value": payload, "name": FROM_FILE_TAG}
         return func(**kwargs)
     return _decorator
 
 
-def setup_template_from_file(bos_cli):
+def setup_template_from_file(command):
     """ Adds a --file parameter for session template creation """
-    command = bos_cli.commands['sessiontemplate'].commands['create']
     option('--file', callback=_opt_callback, type=str, default='', metavar='TEXT',
            help="A file containing the json for a template")(command)
     params = [command.params[-1]]
     for param in command.params[:-1]:
-        if not param.help or 'DEPRECATED' not in param.help:
+        if not getattr(param, 'help', None) or 'DEPRECATED' not in param.help:
             params.append(param)
     command.params = params
     command.callback = create_templates_shim(command.callback)
 
 
-setup_template_from_file(cli)
+def updatemany_data_handler(args):
+    """ Handler to override the api action taken for updatemany """
+    _, path, data = args
+    return "PATCH", path, data
+
+
+def create_patch_shim(func):
+    """ Callback function to custom create our own payload """
+    def _decorator(filter_ids, filter_session, patch, enabled, **kwargs):
+        filter_ids=filter_ids["value"]
+        filter_session=filter_session["value"]
+        if not (filter_ids or filter_session):
+            raise Exception('Either the ids or session filter must be provided')
+        if filter_ids and filter_session:
+            raise Exception('Only one of the two filter options can be provided')
+        payload = {}
+        if filter_ids:
+            payload["filters"] = {"ids": filter_ids}
+        if filter_session:
+            payload["filters"] = {"session": filter_session}
+        if patch["value"]:
+            payload["patch"] = json.loads(patch["value"])
+        else:
+            payload["patch"] = {}
+        if enabled["value"] is not None:
+            payload["patch"]["enabled"] = enabled["value"]
+        # Hack to tell the CLI we are passing our own payload; don't generate
+        kwargs[FROM_FILE_TAG] = {"value": payload, "name": FROM_FILE_TAG}
+        return func(data_handler=updatemany_data_handler, **kwargs)
+    return _decorator
+
+
+def setup_components_patch():
+    """ Sets up an updatemany command for components """
+    source_command = cli.commands['v2'].commands['components'].commands['list']
+    command_type = type(source_command)
+    new_command = command_type("updatemany")
+    for key, value in source_command.__dict__.items():
+        setattr(new_command, key, value)
+    cli.commands['v2'].commands['components'].commands['updatemany'] = new_command
+    new_command.params = []
+    default_params = [param for param in source_command.params if not param.expose_value]
+    option('--filter-ids', callback=_opt_callback, type=str, default='', metavar='TEXT',
+           help="A comma separated list of nodes to patch")(new_command)
+    option('--filter-session', callback=_opt_callback, type=str, default='', metavar='TEXT',
+           help="Patch all components owned by this session")(new_command)
+    option('--patch', callback=_opt_callback, type=str, default='', metavar='TEXT',
+           help="Json component data applied to all filtered components")(new_command)
+    option('--enabled', callback=_opt_callback, type=bool, default=None, metavar='BOOLEAN',
+           help="Shortcut for --patch '{\"enabled\":True/False}'")(new_command)
+    new_command.params += default_params
+    new_command.callback = create_patch_shim(new_command.callback)
+
+
+def setup_v2_template_create():
+    """ Sets up a sessiontemplate create operation in addition to the update operation """
+    TEMP_SWAGGER_OPTS = {
+        'vocabulary': {
+            'put': 'create'
+        }
+    }
+    temp_cli = generate(__file__, swagger_opts=TEMP_SWAGGER_OPTS)
+    cli.commands['v2'].commands['sessiontemplates'].commands['create'] = \
+        temp_cli.commands['v2'].commands['sessiontemplates'].commands['create']
+
+
+
+setup_v2_template_create()
+
+setup_template_from_file(cli.commands['sessiontemplate'].commands['create'])
+setup_template_from_file(cli.commands['v2'].commands['sessiontemplates'].commands['create'])
+setup_template_from_file(cli.commands['v2'].commands['sessiontemplates'].commands['update'])
+
+setup_components_patch()

--- a/cray/modules/bos/openapi.yaml
+++ b/cray/modules/bos/openapi.yaml
@@ -1,17 +1,38 @@
-# Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # Cray Boot Orchestration Service (BOS) API Specification
 openapi: "3.0.2"
 
 info:
   title: "Boot Orchestration Service"
-  version: "1.5.0"
+  version: "0.0.0-api"
   description: |
-    The Boot Orchestration Service (BOS) applies 1 of 4 possible
-    actions (boot, reboot, reconfigure, shutdown) to a list of compute nodes
-    using a specified image (if applicable), with specified kernel parameters,
-    over a specified network. Currently, only one network option is available.
-    After boot or reboot, nodes can be reconfigured.
-
+    The Boot Orchestration Service (BOS) provides coordinated provisioning actions
+    over defined hardware sets to enable boot, reboot, shutdown, configuration and
+    staging for specified hardware subsets. These provisioning actions apply state
+    through numerous system management APIs at the request of system administrators
+    for managed product environments.
 
     The default content type for the BOS API is "application/json". Unsuccessful
     API calls return a content type of "application/problem+json" as per RFC 7807.
@@ -21,16 +42,17 @@ info:
 
     ### /sessiontemplate
 
-    A session template controls the activity of BOS; it is a collection of one or more boot
-    sets, combined with partition information, and
-    configuration detail.
+    A session template sets the operational context of which nodes to operate on for
+    any given set of nodes. It is largely comprised of one or more boot
+    sets and their associated software configuration.
 
     A boot set defines a list of nodes, the image you want to boot/reboot the nodes with,
-    kernel parameters to use to boot the nodes, and the network to boot the nodes over.
+    kernel parameters to use to boot the nodes, and additional configuration management
+    framework actions to apply during node bring up.
 
     ### /session
 
-    A BOS session applies the action to the nodes in the session
+    A BOS session applies a provided action to the nodes defined in a session
     template.
 
     ## Workflow
@@ -55,14 +77,14 @@ info:
 
     #### POST /session
 
-    Specify templateUuid and an
+    Specify template_name and an
     operation to create a new session.
-    The templateUuid corresponds to the session template *name*.
+    The template_name corresponds to the session template *name*.
     A new session is launched as a result of this call.
 
     A limit can also be specified to narrow the scope of the session. The limit
-    can consist of nodes, groups or roles in a comma-seperated list.
-    Multiple groups are treated as seperated by OR, unless "&" is added to
+    can consist of nodes, groups or roles in a comma-separated list.
+    Multiple groups are treated as separated by OR, unless "&" is added to
     the start of the component, in which case this becomes an AND.  Components
     can also be preceded by "!" to exclude them.
 
@@ -108,6 +130,53 @@ components:
         apiStatus:
           type: string
       additionalProperties: false
+    Version:
+      description: Version data
+      type: object
+      properties:
+        major:
+          type: integer
+        minor:
+          type: integer
+        patch:
+          type: integer
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+      additionalProperties: false
+    ProblemDetails:
+      description: An error response for RFC 7807 problem details.
+      type: object
+      properties:
+        type:
+          description:
+            Relative URI reference to the type of problem which includes human
+            readable documentation.
+          type: string
+          format: uri
+          default: "about:blank"
+        title:
+          description:
+            Short, human-readable summary of the problem, should not change by
+            occurrence.
+          type: string
+        status:
+          description: HTTP status code
+          type: integer
+          example: 400
+        instance:
+          description: A relative URI reference that identifies the specific
+            occurrence of the problem
+          format: uri
+          type: string
+        detail:
+          description:
+            A human-readable explanation specific to this occurrence of the
+            problem. Focus on helping correct the problem, rather than giving
+            debugging information.
+          type: string
+      additionalProperties: false
     Link:
       description: Link to other resources
       type: object
@@ -117,7 +186,173 @@ components:
         href:
           type: string
       additionalProperties: false
-    BootSet:
+    # V1
+    V1CfsParameters:
+      type: object
+      description: |
+        CFS Parameters is the collection of parameters that are passed to the Configuration
+        Framework Service when configuration is enabled.
+      properties:
+        clone_url:
+          type: string
+          description: |
+            The clone url for the repository providing the configuration. (DEPRECATED)
+        branch:
+          type: string
+          description: |
+            The name of the branch containing the configuration that you want to
+            apply to the nodes. Mutually exclusive with commit. (DEPRECATED)
+        commit:
+          type: string
+          description: |
+            The commit id of the configuration that you want to
+            apply to the nodes. Mutually exclusive with branch. (DEPRECATED)
+        playbook:
+          type: string
+          description: |
+            The name of the playbook to run for configuration. The file path must be specified
+            relative to the base directory of the config repo. (DEPRECATED)
+        configuration:
+          type: string
+          description: |
+            The name of configuration to be applied.
+      additionalProperties: false
+    V1GenericMetadata:
+      type: object
+      description: |
+        The status metadata
+      properties:
+        start_time:
+          type: string
+          description: |
+            The start time
+          example: "2020-04-24T12:00"
+        stop_time:
+          type: string
+          description: |
+            The stop time
+          example: "2020-04-24T12:00"
+        complete:
+          type: boolean
+          description: |
+            Is the object's status complete
+          example: true
+        in_progress:
+          type: boolean
+          description: |
+            Is the object still doing something
+          example: false
+        error_count:
+          type: integer
+          description: |
+            How many errors were encountered
+          example: 0
+      additionalProperties: false
+    V1NodeList:
+      type: array
+      items:
+        type: string
+        example: ["x3000c0s19b1n0", "x3000c0s19b2n0"]
+    V1PhaseCategoryStatus:
+      type: object
+      description: |
+        A list of the nodes in a given category within a phase.
+
+        ## Link Relationships
+
+        * self : The session object
+
+      properties:
+        name:
+          type: string
+          description: |
+            Name of the Phase Category
+          example: "Succeeded"
+          pattern: '^(?i)not_started|in_progress|succeeded|failed|excluded$'
+        node_list:
+          $ref: '#/components/schemas/V1NodeList'
+    V1PhaseStatus:
+      type: object
+      description: |
+        The phase's status. It is a list of all of the nodes in the phase and
+        what category those nodes fall into within the phase.
+
+        ## Link Relationships
+
+        * self : The session object
+
+      properties:
+        name:
+          type: string
+          description: |
+            Name of the Phase
+          example: "Boot"
+          pattern: '^(?i)boot|configure|shutdown$'
+        metadata:
+          $ref: '#/components/schemas/V1GenericMetadata'
+        categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/V1PhaseCategoryStatus'
+        errors:
+          $ref: '#/components/schemas/V1NodeErrorsList'
+    V1BootSetStatus:
+      type: object
+      description: |
+        The status for a Boot Set. It as a list of the phase statuses for the Boot Set.
+
+        ## Link Relationships
+
+        * self : The session object
+        * phase : A phase of the boot set
+
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Name of the Boot Set
+          example: "Boot-Set"
+        session:
+          type: string
+          description: Session ID
+          example: "Session-ID"
+        metadata:
+          $ref: '#/components/schemas/V1GenericMetadata'
+        phases:
+          type: array
+          items:
+            $ref: '#/components/schemas/V1PhaseStatus'
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+    V1SessionStatus:
+      type: object
+      description: |
+        The status for a Boot Session. It is a list of all of the Boot Set Statuses in the session.
+        ## Link Relationships
+
+        * self : The session object
+        * boot sets: URL to access the Boot Set status
+
+      properties:
+        metadata:
+          $ref: '#/components/schemas/V1GenericMetadata'
+        boot_sets:
+           description: |
+             The boot sets in the Session
+           type: array
+           items:
+             type: string
+           minItems: 1
+        id:
+          type: string
+          description: Session ID
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+    V1BootSet:
       description: |
         A boot set defines a collection of nodes and the information about the
         boot artifacts and parameters to be sent to each node over the specified
@@ -199,178 +434,7 @@ components:
             the 'rootfs=<protocol>' kernel parameter
       additionalProperties: false
       required: [path, type]
-
-    CfsParameters:
-      type: object
-      description: |
-        CFS Parameters is the collection of parameters that are passed to the Configuration
-        Framework Service when configuration is enabled.
-      properties:
-        clone_url:
-          type: string
-          description: |
-            The clone url for the repository providing the configuration. (DEPRECATED)
-        branch:
-          type: string
-          description: |
-            The name of the branch containing the configuration that you want to
-            apply to the nodes. Mutually exclusive with commit. (DEPRECATED)
-        commit:
-          type: string
-          description: |
-            The commit id of the configuration that you want to
-            apply to the nodes. Mutually exclusive with branch. (DEPRECATED)
-        playbook:
-          type: string
-          description: |
-            The name of the playbook to run for configuration. The file path must be specified
-            relative to the base directory of the config repo. (DEPRECATED)
-        configuration:
-          type: string
-          description: |
-            The name of configuration to be applied.
-      additionalProperties: false
-
-    GenericMetadata:
-      type: object
-      description: |
-        The status metadata
-      properties:
-        start_time:
-          type: string
-          description: |
-            The start time
-          example: "2020-04-24T12:00"
-        stop_time:
-          type: string
-          description: |
-            The stop time
-          example: "2020-04-24T12:00"
-        complete:
-          type: boolean
-          description: |
-            Is the object's status complete
-          example: true
-        in_progress:
-          type: boolean
-          description: |
-            Is the object still doing something
-          example: false
-        error_count:
-          type: integer
-          description: |
-            How many errors were encountered
-          example: 0
-      additionalProperties: false
-    NodeList:
-      type: array
-      items:
-        type: string
-        example: ["x3000c0s19b1n0", "x3000c0s19b2n0"]
-    PhaseCategoryStatus:
-      type: object
-      description: |
-        A list of the nodes in a given category within a phase.
-
-        ## Link Relationships
-
-        * self : The session object
-
-      properties:
-        name:
-          type: string
-          description: |
-            Name of the Phase Category
-          example: "Succeeded"
-          pattern: '^(?i)not_started|in_progress|succeeded|failed|excluded$'
-        node_list:
-          $ref: '#/components/schemas/NodeList'
-
-    PhaseStatus:
-      type: object
-      description: |
-        The phase's status. It is a list of all of the nodes in the phase and
-        what category those nodes fall into within the phase.
-
-        ## Link Relationships
-
-        * self : The session object
-
-      properties:
-        name:
-          type: string
-          description: |
-            Name of the Phase
-          example: "Boot"
-          pattern: '^(?i)boot|configure|shutdown$'
-        metadata:
-          $ref: '#/components/schemas/GenericMetadata'
-        categories:
-          type: array
-          items:
-            $ref: '#/components/schemas/PhaseCategoryStatus'
-        errors:
-          $ref: '#/components/schemas/NodeErrorsList'
-
-    BootSetStatus:
-      type: object
-      description: |
-        The status for a Boot Set. It as a list of the phase statuses for the Boot Set.
-
-        ## Link Relationships
-
-        * self : The session object
-        * phase : A phase of the boot set
-
-      properties:
-        name:
-          type: string
-          minLength: 1
-          description: Name of the Boot Set
-          example: "Boot-Set"
-        session:
-          type: string
-          description: Session ID
-          example: "Session-ID"
-        metadata:
-          $ref: '#/components/schemas/GenericMetadata'
-        phases:
-          type: array
-          items:
-            $ref: '#/components/schemas/PhaseStatus'
-        links:
-          type: array
-          items:
-            $ref: '#/components/schemas/Link'
-
-    SessionStatus:
-      type: object
-      description: |
-        The status for a Boot Session. It is a list of all of the Boot Set Statuses in the session.
-        ## Link Relationships
-
-        * self : The session object
-        * boot sets: URL to access the Boot Set status
-
-      properties:
-        metadata:
-          $ref: '#/components/schemas/GenericMetadata'
-        boot_sets:
-           description: |
-             The boot sets in the Session
-           type: array
-           items:
-             type: string
-           minItems: 1
-        id:
-          type: string
-          description: Session ID
-        links:
-          type: array
-          items:
-            $ref: '#/components/schemas/Link'
-
-    SessionTemplate:
+    V1SessionTemplate:
       type: object
       description: |
         A Session Template object represents a collection of resources and metadata.
@@ -391,11 +455,7 @@ components:
           description: |
             The URL to the resource providing the session template data.
             Specify either a templateURL, or the other session
-            template parameters (excluding templateBody).
-        templateBody:
-          type: string
-          description: |
-            Do not use. To be removed.
+            template parameters.
         name:
           type: string
           description: Name of the SessionTemplate. The length of the name is restricted to 45 characters.
@@ -424,7 +484,7 @@ components:
             Choices: true/false
           default: true
         cfs:
-          $ref: '#/components/schemas/CfsParameters'
+          $ref: '#/components/schemas/V1CfsParameters'
         partition:
           type: string
           description: |
@@ -432,7 +492,7 @@ components:
         boot_sets:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/BootSet'
+            $ref: '#/components/schemas/V1BootSet'
         links:
           type: array
           readOnly: true
@@ -440,7 +500,7 @@ components:
             $ref: '#/components/schemas/Link'
       required: [name]
       additionalProperties: false
-    Session:
+    V1Session:
       description: |
         A Session object
 
@@ -472,13 +532,25 @@ components:
           pattern: '^(?i)boot|configure|reboot|shutdown$'
         templateUuid:
           type: string
+          description: DEPRECATED - use templateName
+          example: "my-session-template"
+          format: string
+        templateName:
+          type: string
           description: The name of the Session Template
           example: "my-session-template"
           format: string
+        job:
+          type: string
+          maxLength: 64
+          readOnly: true
+          description: >
+            The identity of the k8s job that is created to handle the session.
+          example: "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
         limit:
           type: string
           description: >
-            A comma seperated of nodes, groups or roles to which the session
+            A comma separated of nodes, groups or roles to which the session
             will be limited. Components are treated as OR operations unless
             preceded by "&" for AND or "!" for NOT.
         links:
@@ -486,24 +558,9 @@ components:
           readOnly: true
           items:
             $ref: '#/components/schemas/Link'
-      required: [operation, templateUuid]
+      required: [operation]
       additionalProperties: false
-    Version:
-      description: Version data
-      type: object
-      properties:
-        major:
-          type: integer
-        minor:
-          type: integer
-        patch:
-          type: integer
-        links:
-          type: array
-          items:
-            $ref: '#/components/schemas/Link'
-      additionalProperties: false
-    NodeChangeList:
+    V1NodeChangeList:
       type: object
       description: |
         The information used to update the status of a node list. It moves nodes from
@@ -519,19 +576,18 @@ components:
           type: string
           example: "Succeeded"
         node_list:
-          $ref: '#/components/schemas/NodeList'
+          $ref: '#/components/schemas/V1NodeList'
       additionalProperties: false
       required: [phase, source, destination, node_list]
-    NodeErrorsList:
+    V1NodeErrorsList:
       type: object
       description: |
         Categorizing nodes into failures by the type of error they have.
         This is an additive characterization. Nodes will be added to existing errors.
         This does not overwrite previously existing errors.
       additionalProperties:
-        $ref: '#/components/schemas/NodeList'
-        default: {}
-    UpdateRequestNodeChangeList:
+        $ref: '#/components/schemas/V1NodeList'
+    V1UpdateRequestNodeChangeList:
       description: |
         This is the payload sent during an update request. It contains
         updates to which categories nodes are in.
@@ -550,8 +606,8 @@ components:
             pattern: "(?i)shutdown|boot|configure"
             type: string
           data:
-            $ref: '#/components/schemas/NodeChangeList'
-    UpdateRequestNodeErrorsList:
+            $ref: '#/components/schemas/V1NodeChangeList'
+    V1UpdateRequestNodeErrorsList:
       description: |
         This is the payload sent during an update request. It contains
         updates to which errors have occurred and which nodes encountered those errors
@@ -570,8 +626,8 @@ components:
             pattern: "(?i)shutdown|boot|configure"
             type: string
           data:
-            $ref: '#/components/schemas/NodeErrorsList'
-    UpdateRequestGenericMetadata:
+            $ref: '#/components/schemas/V1NodeErrorsList'
+    V1UpdateRequestGenericMetadata:
       description: |
         This is the payload sent during an update request. It contains
         updates to metadata, specifically start and stop times
@@ -590,79 +646,735 @@ components:
             pattern: '(?i)shutdown|boot|configure|boot_set'
             type: string
           data:
-            $ref: '#/components/schemas/GenericMetadata'
-    ProblemDetails:
-      description: An error response for RFC 7807 problem details.
+            $ref: '#/components/schemas/V1GenericMetadata'
+    # V2
+    V2CfsParameters:
+      type: object
+      description: |
+        CFS Parameters is the collection of parameters that are passed to the Configuration
+        Framework Service when configuration is enabled. Can be set as the global value for
+        a Session Template, or individually within a boot set.
+      properties:
+        configuration:
+          type: string
+          description: |
+            The name of configuration to be applied.
+      additionalProperties: false
+    V2SessionTemplate:
+      type: object
+      description: |
+        A Session Template object represents a collection of resources and metadata.
+        A session template is used to create a Session which applies the data to
+        group of components.
+
+        A Session Template can be created from a JSON structure.  It will return
+        a SessionTemplate name if successful.
+        This name is required when creating a Session.
+
+        ## Link Relationships
+
+        * self : The session object
+      properties:
+        name:
+          type: string
+          description: Name of the SessionTemplate. The length of the name is restricted to 45 characters.
+          example: "cle-1.0.0"
+          # These validation parameters are restricted by Kubernetes naming conventions.
+          minLength: 1
+          maxLength: 45
+          pattern: "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+          readOnly: true
+        description:
+          type: string
+          description: |
+            An optional description for the session template.
+        enable_cfs:
+          type: boolean
+          description: |
+            Whether to enable the Configuration Framework Service (CFS).
+            Choices: true/false
+          default: true
+        cfs:
+          $ref: '#/components/schemas/V2CfsParameters'
+        boot_sets:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/V2BootSet'
+        links:
+          type: array
+          readOnly: true
+          items:
+            $ref: '#/components/schemas/Link'
+      required: []
+      additionalProperties: false
+    V2SessionTemplateArray:
+      description: An array of session templates.
+      type: array
+      items:
+        $ref: '#/components/schemas/V2SessionTemplate'
+    V2SessionTemplateValidation:
+      description: |
+        Message describing errors or incompleteness in a Session Template.
+      type: string
+    V2SessionCreate:
+      description: |
+        A Session Creation object
       type: object
       properties:
-        type:
-          description:
-            Relative URI reference to the type of problem which includes human
-            readable documentation.
+        name:
           type: string
-          format: uri
-          default: "about:blank"
-        title:
-          description:
-            Short, human-readable summary of the problem, should not change by
-            occurrence.
+          description: Name of the session. A uuid name is generated if a name is not provided.
+          example: "session-20190728032600"
+          # These validation parameters are restricted by Kubernetes naming conventions.
+          minLength: 1
+          maxLength: 45
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+        operation:
           type: string
-        status:
-          description: HTTP status code
-          type: integer
-          example: 400
-        instance:
-          description: A relative URI reference that identifies the specific
-            occurrence of the problem
-          format: uri
+          enum: ['boot', 'reboot', 'shutdown']
+          description: >
+            A Session represents a desired state that is being applied to a group
+            of components.  Sessions run until all components it manages have
+            either been disabled due to completion, or until all components are
+            managed by other newer sessions.
+
+            Operation -- An operation to perform on nodes in this session.
+                Boot                 Applies the template to the components and boots/reboots if necessary.
+                Reboot               Applies the template to the components guarantees a reboot.
+                Shutdown             Power down nodes that are on.
+        template_name:
           type: string
-        detail:
-          description:
-            A human-readable explanation specific to this occurrence of the
-            problem. Focus on helping correct the problem, rather than giving
-            debugging information.
+          description: The name of the Session Template
+          example: "my-session-template"
+          format: string
+        limit:
           type: string
+          description: >
+            A comma separated of nodes, groups or roles to which the session
+            will be limited. Components are treated as OR operations unless
+            preceded by "&" for AND or "!" for NOT.
+        stage:
+          type: boolean
+          description: >
+            Set to force nodes to reboot even if they are already in the desired
+            state.
+          default: false
+      required: [operation, template_name]
       additionalProperties: false
+    V2SessionStatus:
+      type: object
+      description: |
+        Information on the status of a session.
+      properties:
+        start_time:
+          type: string
+          description: |
+            When the session was created.
+        end_time:
+          type: string
+          description: |
+            When the session completed.
+        status:
+          type: string
+          enum: ['pending', 'running', 'complete']
+          description: |
+            The status of a session.
+        error:
+          type: string
+          description: |
+            Error which prevented the session from running
+      additionalProperties: false
+    V2BootSet:
+      description: |
+        A boot set is a collection of nodes defined by an explicit list, their functional
+        role, and their logical groupings. This collection of nodes is associated with one
+        set of boot artifacts and optional additional records for configuration and root
+        filesystem provisioning.
+      type: object
+      properties:
+        name:
+          type: string
+          description: |
+            The Boot Set name.
+        path:
+          type: string
+          description: |
+            A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.
+            It will be processed based on the type attribute.
+        cfs:
+          $ref: '#/components/schemas/V2CfsParameters'
+        type:
+          type: string
+          description: |
+            The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.
+        etag:
+          type: string
+          description: |
+            This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.
+        kernel_parameters:
+          type: string
+          description: |
+            The kernel parameters to use to boot the nodes.
+        node_list:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: |
+            The node list. This is an explicit mapping against hardware xnames.
+        node_roles_groups:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: |
+            The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.
+        node_groups:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: |
+            The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.
+        rootfs_provider:
+          type: string
+          description: |
+            The root file system provider.
+        rootfs_provider_passthrough:
+          type: string
+          description: |
+            The root file system provider passthrough.
+            These are additional kernel parameters that will be appended to
+            the 'rootfs=<protocol>' kernel parameter
+      additionalProperties: false
+      required: [path, type]
+    V2Session:
+      description: |
+        A Session object
+
+        ## Link Relationships
+
+        * self : The session object
+      type: object
+      properties:
+        name:
+          type: string
+          description: >
+            Name of the session.
+        operation:
+          type: string
+          enum: ['boot', 'reboot', 'shutdown']
+          description: >
+            A Session represents a desired state that is being applied to a group
+            of components.  Sessions run until all components it manages have
+            either been disabled due to completion, or until all components are
+            managed by other newer sessions.
+
+            Operation -- An operation to perform on nodes in this session.
+                Boot                 Applies the template to the components and boots/reboots if necessary.
+                Reboot               Applies the template to the components guarantees a reboot.
+                Shutdown             Power down nodes that are on.
+        template_name:
+          type: string
+          description: The name of the Session Template
+          example: "my-session-template"
+          format: string
+        limit:
+          type: string
+          description: >
+            A comma separated of nodes, groups or roles to which the session
+            will be limited. Components are treated as OR operations unless
+            preceded by "&" for AND or "!" for NOT.
+        stage:
+          type: boolean
+          description: >
+            Set to stage a session which will not immediately change the state of any components.
+            The "applystaged" endpoint can be called at a later time to trigger the start of this session.
+        components:
+          type: string
+          description: >
+            A comma separated list of nodes, representing the initial list of nodes
+            the session should operate against.  The list will remain even if
+            other sessions have taken over management of the nodes.
+        status:
+          $ref: '#/components/schemas/V2SessionStatus'
+      additionalProperties: false
+    V2SessionArray:
+      description: An array of sessions.
+      type: array
+      items:
+        $ref: '#/components/schemas/V2Session'
+    V2SessionExtendedStatusPhases:
+      type: object
+      description: |
+        Detailed information on the phases of a session.
+      properties:
+        percent_complete:
+          type: float
+          description: |
+            The percent of components currently in a completed/stable state
+        percent_powering_on:
+          type: float
+          description: |
+            The percent of components currently in the powering-on phase
+        percent_powering_off:
+          type: float
+          description: |
+            The percent of components currently in the powering-off phase
+        percent_configuring:
+          type: float
+          description: |
+            The percent of components currently in the configuring phase
+      additionalProperties: false
+    V2SessionExtendedStatusTiming:
+      type: object
+      description: |
+        Detailed information on the timing of a session.
+      properties:
+        start_time:
+          type: string
+          description: |
+            When the session was created.
+        end_time:
+          type: string
+          description: |
+            When the session completed.
+        duration:
+          type: string
+          description: |
+            The current duration of the on-going session or final duration of the completed session.
+      additionalProperties: false
+    V2SessionExtendedStatus:
+      type: object
+      description: |
+        Detailed information on the status of a session.
+      properties:
+        status:
+          type: string
+          enum: ['pending', 'running', 'complete']
+          description: |
+            The status of a session.
+        managed_components_count:
+          type: integer
+          description: |
+            The count of components currently managed by this session
+        phases:
+          $ref: '#/components/schemas/V2SessionExtendedStatusPhases'
+        percent_successful:
+          type: float
+          description: |
+            The percent of components currently in a successful state
+        percent_failed:
+          type: float
+          description: |
+            The percent of components currently in a failed state
+        percent_staged:
+          type: float
+          description: |
+            The percent of components currently still staged for this session
+        error_summary:
+          type: object
+          description: |
+            A summary of the errors currently listed by all components
+        timing:
+          $ref: '#/components/schemas/V2SessionExtendedStatusTiming'
+      additionalProperties: false
+    V2BootArtifacts:
+      description: |
+        A collection of boot artifacts.
+      type: object
+      properties:
+        kernel:
+          type: string
+          description: An md5sum hash of the kernel ID
+        kernel_parameters:
+          type: string
+          description: Kernel parameters
+        initrd:
+          type: string
+          description: Initrd ID
+      additionalProperties: false
+    V2ComponentActualState:
+      description: |
+        The desired boot artifacts and configuration for a component
+      type: object
+      properties:
+        boot_artifacts:
+          $ref: '#/components/schemas/V2BootArtifacts'
+        bss_token:
+          type: string
+          description: >
+            A token received from the node identifying the boot artifacts. 
+            For BOS use-only, users should not set this field. It will be overwritten.
+        last_updated:
+          type: string
+          description: The date/time when the state was last updated in RFC 3339 format.
+          example: '2019-07-28T03:26:00Z'
+          format: date-time
+          readOnly: true
+    V2ComponentDesiredState:
+      description: |
+        The desired boot artifacts and configuration for a component
+      type: object
+      properties:
+        boot_artifacts:
+          $ref: '#/components/schemas/V2BootArtifacts'
+        configuration:
+          type: string
+          description: A CFS configuration ID.
+        bss_token:
+          type: string
+          description: >
+            A token received from BSS identifying the boot artifacts. 
+            For BOS use-only, users should not set this field. It will be overwritten.
+        last_updated:
+          type: string
+          description: The date/time when the state was last updated in RFC 3339 format.
+          example: '2019-07-28T03:26:00Z'
+          format: date-time
+          readOnly: true
+      additionalProperties: false
+    V2ComponentStagedState:
+      description: |
+        The desired boot artifacts and configuration for a component
+      type: object
+      properties:
+        boot_artifacts:
+          $ref: '#/components/schemas/V2BootArtifacts'
+        configuration:
+          type: string
+          description: A CFS configuration ID.
+        session:
+          type: string
+          description: A session which can be triggered at a later time against this component.
+        last_updated:
+          type: string
+          description: The date/time when the state was last updated in RFC 3339 format.
+          example: '2019-07-28T03:26:00Z'
+          format: date-time
+          readOnly: true
+      additionalProperties: false
+    V2ComponentLastAction:
+      description: |
+        Information on the most recent action taken against the node.
+      type: object
+      properties:
+        last_updated:
+          type: string
+          description: The date/time when the state was last updated in RFC 3339 format.
+          example: '2019-07-28T03:26:00Z'
+          format: date-time
+          readOnly: true
+        action:
+          type: string
+          description: A description of the most recent operator/action to impact the component.
+        num_attempts:
+          type: integer
+          description: How many attempts have been made for this action.
+      additionalProperties: false
+    V2ComponentStatus:
+      description: Status information for the component
+      type: object
+      properties:
+        phase:
+          type: string
+          description: The current phase of the component in the boot process.
+        status:
+          type: string
+          description: The current status of the component.  More detailed than phase.
+          readOnly: true
+        status_override:
+          type: string
+          description: If set, this will override the status value.
+      additionalProperties: false
+    V2Component:
+      description: |
+        The current and desired artifacts state for a component.
+      type: object
+      properties:
+        id:
+          type: string
+          description: The component's id. e.g. xname for hardware components
+        actual_state:
+          $ref: '#/components/schemas/V2ComponentActualState'
+        desired_state:
+          $ref: '#/components/schemas/V2ComponentDesiredState'
+        staged_state:
+          $ref: '#/components/schemas/V2ComponentStagedState'
+        last_action:
+          $ref: '#/components/schemas/V2ComponentLastAction'
+        status:
+          $ref: '#/components/schemas/V2ComponentStatus'
+        enabled:
+          type: boolean
+          description: A flag indicating if actions should be taken for this component.
+        error:
+          type: string
+          description: A description of the most recent error to impact the component.
+        session:
+          type: string
+          description: The session responsible for the component's current state
+      additionalProperties: false
+    V2ComponentArray:
+      description: An array of component states.
+      type: array
+      items:
+        $ref: '#/components/schemas/V2Component'
+    V2ComponentsFilter:
+      description: Information for patching multiple components.
+      type: object
+      properties:
+        ids:
+          type: string
+          description: A comma separated list of component ids
+        session:
+          type: string
+          description: A session name.  All components part of this session will be patched.
+    V2ComponentsUpdate:
+      description: Information for patching multiple components.
+      type: object
+      properties:
+        patch:
+          $ref: '#/components/schemas/V2Component'
+        filters:
+          $ref: '#/components/schemas/V2ComponentsFilter'
+      required: [patch, filters]
+    V2ApplyStagedComponents:
+      description: |
+        A list of components that should have their staged session applied.
+      type: object
+      properties:
+        xnames:
+          description: The list of component xnames
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+    V2ApplyStagedStatus:
+      description: |
+        A list of components that should have their staged session applied.
+      type: object
+      properties:
+        succeeded:
+          description: The list of component xnames
+          type: array
+          items:
+            type: string
+        failed:
+          description: The list of component xnames
+          type: array
+          items:
+            type: string
+        ignored:
+          description: The list of component xnames
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+    V2Options:
+      description: |
+        Options for the boot orchestration service.
+      type: object
+      properties:
+        cleanup_completed_session_ttl:
+          type: string
+          description: Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior.
+        component_actual_state_ttl:
+          type: string
+          description: The maximum amount of time a component's actual state is considered valid (in hours). 0h disables cleanup behavior for newly booted nodes and instructs bos-state-reporter to report once instead of periodically.
+        disable_components_on_completion:
+          type: boolean
+          description: Allows for BOS components to be marked as disabled after a session has been completed. If false, BOS will continue to maintain the state of the nodes declaratively, even after a session finishes. 
+        discovery_frequency:
+          type: integer
+          description: How frequently the BOS discovery agent syncs new components from HSM. (in seconds)
+        logging_level:
+          type: string
+          description: The logging level for all BOS services
+        max_power_on_wait_time:
+          type: integer
+          description: How long BOS will wait for a node to power on before rebooting again (in seconds)
+        max_power_off_wait_time:
+          type: integer
+          description: How long BOS will wait for a node to power off before forcefully powering off (in seconds)
+        polling_frequency:
+          type: integer
+          description: How frequently the BOS operators check component state for needed actions. (in seconds)
+      additionalProperties: true
+  requestBodies:
+    V2sessionCreateRequest:
+      description: The information to create a session
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2SessionCreate'
+    V2componentUpdateRequest:
+      description: The state for a single component
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2Component'
+    V2componentsPutRequest:
+      description: The state for an array of components
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2ComponentArray'
+    V2componentsUpdateRequest:
+      description: The state for an array of components
+      required: true
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/V2ComponentsUpdate'
+              - $ref: '#/components/schemas/V2ComponentArray'
+    V2optionsUpdateRequest:
+      description: Service-wide options
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2Options'
+    V2sessionUpdateRequest:
+      description: The state for a single session
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2Session'
+    V2applyStagedRequest:
+      description: A list of xnames that should have their staged session applied.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2ApplyStagedComponents'
 
   responses:
-    badRequest:
+    ServiceHealth:
+      description: Service Health information
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Healthz'
+    Version:
+      description: |
+        Get version details
+        The versioning system uses [semver](https://semver.org/).
+        ## Link Relationships
+        * self : Link to itself
+        * versions : Link back to the versions resource
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Version'
+    ResourceDeleted:
+      description: The resource was deleted.
+    # V1
+    V1SessionDetails:
+      description: Session details
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V1Session'
+    V1SessionStatus:
+      description: A list of Boot Set Statuses and metadata
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V1SessionStatus'
+    V1SessionTemplateDetails:
+      description: Session template details
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V1SessionTemplate'
+    # V2
+    V2SessionTemplateDetails:
+      description: Session template details
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2SessionTemplate'
+    V2SessionTemplateDetailsArray:
+      description: Session template details
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2SessionTemplateArray'
+    V2SessionTemplateValidation:
+      description: Session template validity details
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2SessionTemplateValidation'
+    V2SessionDetails:
+      description: Session details
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2Session'
+    V2SessionDetailsArray:
+      description: Session details
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2SessionArray'
+    V2SessionExtendedStatus:
+      description: Session status details
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2SessionExtendedStatus'
+    V2componentDetails:
+      description: A single component state
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2Component'
+    V2componentDetailsArray:
+      description: A collection of component states
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2ComponentArray'
+    V2applyStagedResponse:
+      description: A list of xnames that should have their staged session applied.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2ApplyStagedStatus'
+    V2options:
+      description: A collection of service-wide options
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2Options'
+    # Errors
+    BadRequest:
       description: Bad Request
       content:
         application/problem+json:
           schema:
             $ref: '#/components/schemas/ProblemDetails'
-    serviceUnavailable:
+    ResourceNotFound:
+      description: The resource was not found.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    ServiceUnavailable:
       description: Service Unavailable
       content:
         application/problem+json:
           schema:
             $ref: '#/components/schemas/ProblemDetails'
-    v1SessionDetails:
-      description: Session details
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Session'
-    v1SessionStatus:
-      description: A list of Boot Set Statuses and metadata
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/SessionStatus'
-    v1SessionTemplateDetails:
-      description: Session template details
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/SessionTemplate'
-    sessionTemplateNotFound:
-      description: The session template was not found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '#/components/schemas/ProblemDetails'
-    sessionNotFound:
-      description: The session was not found
+    InternalError:
+      description: An Internal Server Error occurred handling the request.
       content:
         application/problem+json:
           schema:
@@ -674,24 +1386,10 @@ paths:
       description: Return list of versions currently running.
       tags:
         - version
-      x-openapi-router-controller: bos.controllers.base
+      x-openapi-router-controller: bos.server.controllers.base
       responses:
         200:
-          description: |
-            Get versions.
-
-            The versioning system uses [semver](https://semver.org/).
-
-            ## Link Relationships
-
-            * self : The version base, e.g., "/v1".
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Version'
-
+          $ref: '#/components/responses/Version'
 # See Version guidance is in
 # https://connect.us.cray.com/confluence/display/SMA/Shasta+RESTful+Service+Design#ShastaRESTfulServiceDesign-Versioning
 #
@@ -701,62 +1399,35 @@ paths:
       summary: Get API version
       tags:
         - version
-      x-openapi-router-controller: bos.controllers.v1.base
+      x-openapi-router-controller: bos.server.controllers.v1.base
       operationId: v1_get
       responses:
         200:
-          description: |
-            Get version details
-
-            The versioning system uses [semver](https://semver.org/).
-
-            ## Link Relationships
-
-            * self : Link to itself
-            * versions : Link back to the versions resource
-
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Version'
+          $ref: '#/components/responses/Version'
         500:
-          description: An Internal Server Error occurred handling the request.
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetails'
-
+          $ref: '#/components/responses/BadRequest'
   /v1/healthz:
     get:
       summary: Get service health details
       tags:
         - healthz
-      x-openapi-router-controller: bos.controllers.v1.healthz
+      x-openapi-router-controller: bos.server.controllers.v1.healthz
       operationId: v1_get_healthz
       description:
         Get bos health details.
       responses:
         200:
-         description: Service Health information
-         content:
-           application/json:
-             schema:
-               $ref: '#/components/schemas/Healthz'
+          $ref: '#/components/responses/ServiceHealth'
         500:
-          description: An Internal Server Error occurred handling the request.
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetails'
+          $ref: '#/components/responses/BadRequest'
         503:
-          $ref: '#/components/responses/serviceUnavailable'
-
+          $ref: '#/components/responses/ServiceUnavailable'
   /v1/sessiontemplate:
     post:
       summary: Create session template
       tags:
         - sessiontemplate
-      x-openapi-router-controller: bos.controllers.v1.sessiontemplate
+      x-openapi-router-controller: bos.server.controllers.v1.sessiontemplate
       operationId: create_v1_sessiontemplate
       description:
         Create a new session template.
@@ -766,13 +1437,12 @@ paths:
          content:
            application/json:
              schema:
-               $ref: '#/components/schemas/SessionTemplate'
+               $ref: '#/components/schemas/V1SessionTemplate'
       responses:
         200:
-          $ref: '#/components/responses/v1SessionTemplateDetails'
+          $ref: '#/components/responses/V1SessionTemplateDetails'
         400:
-          $ref: '#/components/responses/badRequest'
-
+          $ref: '#/components/responses/BadRequest'
     get:
       summary: List session templates
       description: |
@@ -780,7 +1450,7 @@ paths:
         uniquely identified by the name.
       tags:
         - sessiontemplate
-      x-openapi-router-controller: bos.controllers.v1.sessiontemplate
+      x-openapi-router-controller: bos.server.controllers.v1.sessiontemplate
       operationId: get_v1_sessiontemplates
       responses:
         200:
@@ -790,8 +1460,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SessionTemplate'
-
+                  $ref: '#/components/schemas/V1SessionTemplate'
   /v1/sessiontemplate/{session_template_id}:
     parameters:
       - name: session_template_id
@@ -808,26 +1477,25 @@ paths:
         of the session template.
       tags:
         - sessiontemplate
-      x-openapi-router-controller: bos.controllers.v1.sessiontemplate
+      x-openapi-router-controller: bos.server.controllers.v1.sessiontemplate
       operationId: get_v1_sessiontemplate
       responses:
         200:
-          $ref: '#/components/responses/v1SessionTemplateDetails'
+          $ref: '#/components/responses/V1SessionTemplateDetails'
         404:
-          $ref: '#/components/responses/sessionTemplateNotFound'
+          $ref: '#/components/responses/ResourceNotFound'
     delete:
       summary: Delete a session template
       description: Delete a session template.
       tags:
         - sessiontemplate
-      x-openapi-router-controller: bos.controllers.v1.sessiontemplate
+      x-openapi-router-controller: bos.server.controllers.v1.sessiontemplate
       operationId: delete_v1_sessiontemplate
       responses:
         204:
-          description: The session template was deleted.
+          $ref: '#/components/responses/ResourceDeleted'
         404:
-          $ref: '#/components/responses/sessionTemplateNotFound'
-
+          $ref: '#/components/responses/ResourceNotFound'
   /v1/sessiontemplatetemplate:
     get:
       summary: Get an example session template.
@@ -837,12 +1505,11 @@ paths:
         session templates.
       tags:
         - sessiontemplate
-      x-openapi-router-controller: bos.controllers.v1.sessiontemplate
+      x-openapi-router-controller: bos.server.controllers.v1.sessiontemplate
       operationId: get_v1_sessiontemplatetemplate
       responses:
         200:
-          $ref: '#/components/responses/v1SessionTemplateDetails'
-
+          $ref: '#/components/responses/V1SessionTemplateDetails'
   /v1/session:
     post:
       summary: Create a session
@@ -852,7 +1519,7 @@ paths:
         on the boot set(s) defined in the session template.
       tags:
         - session
-      x-openapi-router-controller: bos.controllers.v1.session
+      x-openapi-router-controller: bos.server.controllers.v1.session
       operationId: create_v1_session
       requestBody:
          description: A JSON object for creating a Session
@@ -860,20 +1527,19 @@ paths:
          content:
            application/json:
              schema:
-               $ref: '#/components/schemas/Session'
+               $ref: '#/components/schemas/V1Session'
       responses:
         200:
-          $ref: '#/components/responses/v1SessionDetails'
+          $ref: '#/components/responses/V1SessionDetails'
         400:
-          $ref: '#/components/responses/badRequest'
-
+          $ref: '#/components/responses/BadRequest'
     get:
       summary: List sessions
       description: |
         List all sessions, including those in progress and those complete.
       tags:
         - session
-      x-openapi-router-controller: bos.controllers.v1.session
+      x-openapi-router-controller: bos.server.controllers.v1.session
       operationId: get_v1_sessions
       responses:
         200:
@@ -883,35 +1549,32 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Session'
-
-
+                  $ref: '#/components/schemas/V1Session'
   /v1/session/{session_id}:
     get:
       summary: Get session details by id
       description: Get session details by session_id.
       tags:
         - session
-      x-openapi-router-controller: bos.controllers.v1.session
+      x-openapi-router-controller: bos.server.controllers.v1.session
       operationId: get_v1_session
       responses:
         200:
-          $ref: '#/components/responses/v1SessionDetails'
+          $ref: '#/components/responses/V1SessionDetails'
         404:
-          $ref: '#/components/responses/sessionNotFound'
+          $ref: '#/components/responses/ResourceNotFound'
     delete:
       summary: Delete session by id
       description: Delete session by session_id.
       tags:
         - session
-      x-openapi-router-controller: bos.controllers.v1.session
+      x-openapi-router-controller: bos.server.controllers.v1.session
       operationId: delete_v1_session
       responses:
         204:
-          description: The session was deleted.
+          $ref: '#/components/responses/ResourceDeleted'
         404:
-          $ref: '#/components/responses/sessionNotFound'
-
+          $ref: '#/components/responses/ResourceNotFound'
     parameters:
       - name: session_id
         in: path
@@ -919,7 +1582,6 @@ paths:
         required: true
         schema:
           type: string
-
   /v1/session/{session_id}/status:
     parameters:
       - name: session_id
@@ -934,24 +1596,20 @@ paths:
         A list of the statuses for the different boot sets.
       tags:
         - session
-      x-openapi-router-controller: bos.controllers.v1.status
+      x-openapi-router-controller: bos.server.controllers.v1.status
       operationId: get_v1_session_status
       responses:
         200:
-          description: |
-            A collection of boot sets associated with this session.
-
-            The boot set name can be used to query for the status.
-          $ref: '#/components/responses/v1SessionStatus'
+          $ref: '#/components/responses/V1SessionStatus'
         404:
-          $ref: '#/components/responses/sessionNotFound'
+          $ref: '#/components/responses/ResourceNotFound'
     post:
       summary: Create the initial session status
       description: |
         Creates the initial session status.
       tags:
         - session
-      x-openapi-router-controller: bos.controllers.v1.status
+      x-openapi-router-controller: bos.server.controllers.v1.status
       operationId: create_v1_session_status
       requestBody:
          description: A JSON object for creating the status for a session
@@ -959,19 +1617,19 @@ paths:
          content:
            application/json:
              schema:
-               $ref: '#/components/schemas/SessionStatus'
+               $ref: '#/components/schemas/V1SessionStatus'
       responses:
         204:
-          $ref: '#/components/responses/v1SessionStatus'
+          $ref: '#/components/responses/V1SessionStatus'
         400:
-          $ref: '#/components/responses/badRequest'
+          $ref: '#/components/responses/BadRequest'
     patch:
       summary: Update the session status
       description: |
         Update the session status. You can update the start or stop times.
       tags:
         - session
-      x-openapi-router-controller: bos.controllers.v1.status
+      x-openapi-router-controller: bos.server.controllers.v1.status
       operationId: update_v1_session_status
       requestBody:
         description: A JSON object for updating the status for a session
@@ -979,26 +1637,25 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GenericMetadata'
+              $ref: '#/components/schemas/V1GenericMetadata'
       responses:
         200:
-          $ref: '#/components/responses/v1SessionStatus'
+          $ref: '#/components/responses/V1SessionStatus'
         404:
-          $ref: '#/components/responses/badRequest'
+          $ref: '#/components/responses/BadRequest'
     delete:
       summary: Delete the session status
       description: |
         Deletes an existing Session status
       tags:
         - session
-      x-openapi-router-controller: bos.controllers.v1.status
+      x-openapi-router-controller: bos.server.controllers.v1.status
       operationId: delete_v1_session_status
       responses:
         204:
-          description: The status was deleted successfully.
+          $ref: '#/components/responses/ResourceDeleted'
         400:
-          $ref: '#/components/responses/badRequest'
-
+          $ref: '#/components/responses/BadRequest'
   /v1/session/{session_id}/status/{boot_set_name}:
     parameters:
       - name: session_id
@@ -1018,7 +1675,7 @@ paths:
       description: Get the status for a boot set.
       tags:
         - session
-      x-openapi-router-controller: bos.controllers.v1.status
+      x-openapi-router-controller: bos.server.controllers.v1.status
       operationId: get_v1_session_status_by_bootset
       responses:
         200:
@@ -1026,9 +1683,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BootSetStatus'
+                $ref: '#/components/schemas/V1BootSetStatus'
         404:
-          $ref: '#/components/responses/sessionNotFound'
+          $ref: '#/components/responses/ResourceNotFound'
     post:
       summary: Create a Boot Set Status
       description: |
@@ -1036,7 +1693,7 @@ paths:
       tags:
         - session
         - status
-      x-openapi-router-controller: bos.controllers.v1.status
+      x-openapi-router-controller: bos.server.controllers.v1.status
       operationId: create_v1_boot_set_status
       requestBody:
         description: A JSON object for creating a status for a Boot Set
@@ -1044,14 +1701,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BootSetStatus'
+              $ref: '#/components/schemas/V1BootSetStatus'
       responses:
         201:
           description: The created Boot Set status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BootSetStatus'
+                $ref: '#/components/schemas/V1BootSetStatus'
     patch:
       summary: Update the status.
       description: |
@@ -1060,7 +1717,7 @@ paths:
       tags:
         - session
         # - cli_ignore
-      x-openapi-router-controller: bos.controllers.v1.status
+      x-openapi-router-controller: bos.server.controllers.v1.status
       operationId: update_v1_session_status_by_bootset
       requestBody:
          description: A JSON object for updating the status for a session
@@ -1069,32 +1726,31 @@ paths:
            application/json:
              schema:
                anyOf:
-                 - $ref: '#/components/schemas/UpdateRequestNodeChangeList'
-                 - $ref: '#/components/schemas/UpdateRequestNodeErrorsList'
-                 - $ref: '#/components/schemas/UpdateRequestGenericMetadata'
+                 - $ref: '#/components/schemas/V1UpdateRequestNodeChangeList'
+                 - $ref: '#/components/schemas/V1UpdateRequestNodeErrorsList'
+                 - $ref: '#/components/schemas/V1UpdateRequestGenericMetadata'
       responses:
         200:
           description: A list of Boot Set Statuses and metadata
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BootSetStatus'
+                $ref: '#/components/schemas/V1BootSetStatus'
         404:
-          $ref: '#/components/responses/sessionNotFound'
+          $ref: '#/components/responses/ResourceNotFound'
     delete:
       summary: Delete the Boot Set status
       description: |
         Deletes an existing Boot Set status
       tags:
         - session
-      x-openapi-router-controller: bos.controllers.v1.status
+      x-openapi-router-controller: bos.server.controllers.v1.status
       operationId: delete_v1_boot_set_status
       responses:
         204:
-          description: The status was deleted successfully.
+          $ref: '#/components/responses/ResourceDeleted'
         400:
-          $ref: '#/components/responses/badRequest'
-
+          $ref: '#/components/responses/BadRequest'
   /v1/session/{session_id}/status/{boot_set_name}/{phase_name}:
     parameters:
       - name: session_id
@@ -1120,7 +1776,7 @@ paths:
       description: Get the status for a specific boot set and phase.
       tags:
         - session
-      x-openapi-router-controller: bos.controllers.v1.status
+      x-openapi-router-controller: bos.server.controllers.v1.status
       operationId: get_v1_session_status_by_bootset_and_phase
       responses:
         200:
@@ -1128,10 +1784,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PhaseStatus'
+                $ref: '#/components/schemas/V1PhaseStatus'
         404:
-          $ref: '#/components/responses/sessionNotFound'
-
+          $ref: '#/components/responses/ResourceNotFound'
   /v1/session/{session_id}/status/{boot_set_name}/{phase_name}/{category_name}:
     parameters:
       - name: session_id
@@ -1163,7 +1818,7 @@ paths:
       description: Get the status for a specific boot set, phase, and category.
       tags:
         - session
-      x-openapi-router-controller: bos.controllers.v1.status
+      x-openapi-router-controller: bos.server.controllers.v1.status
       operationId: get_v1_session_status_by_bootset_and_phase_and_category
       responses:
         200:
@@ -1171,36 +1826,572 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PhaseCategoryStatus'
+                $ref: '#/components/schemas/V1PhaseCategoryStatus'
         404:
-          $ref: '#/components/responses/sessionNotFound'
-
+          $ref: '#/components/responses/ResourceNotFound'
   /v1/version:
     get:
       summary: Get API version
       tags:
         - version
-      x-openapi-router-controller: bos.controllers.v1.base
+      x-openapi-router-controller: bos.server.controllers.v1.base
       operationId: v1_get_version
       responses:
         200:
-          description: |
-            Get version details
-
-            The versioning system uses [semver](https://semver.org/).
-
-            ## Link Relationships
-
-            * self : Link to itself
-            * versions : Link back to the versions resource
-
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Version'
+          $ref: '#/components/responses/Version'
         500:
-          description: An Internal Server Error occurred handling the request.
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetails'
+          $ref: '#/components/responses/BadRequest'
+
+  /v2:
+    get:
+      summary: Get API version
+      tags:
+        - v2
+        - version
+      x-openapi-router-controller: bos.server.controllers.v2.base
+      operationId: get_v2
+      responses:
+        200:
+          $ref: '#/components/responses/Version'
+        500:
+          $ref: '#/components/responses/BadRequest'
+  /v2/healthz:
+    get:
+      summary: Get service health details
+      tags:
+        - v2
+        - healthz
+      x-openapi-router-controller: bos.server.controllers.v2.healthz
+      operationId: get_v2_healthz
+      description:
+        Get bos health details.
+      responses:
+        200:
+         $ref: '#/components/responses/ServiceHealth'
+        500:
+          $ref: '#/components/responses/BadRequest'
+        503:
+          $ref: '#/components/responses/ServiceUnavailable'
+  /v2/sessiontemplates:
+    get:
+      summary: List session templates
+      description: |
+        List all session templates. Session templates are
+        uniquely identified by the name.
+      tags:
+        - v2
+        - sessiontemplates
+      x-openapi-router-controller: bos.server.controllers.v2.sessiontemplates
+      operationId: get_v2_sessiontemplates
+      responses:
+        200:
+          $ref: '#/components/responses/V2SessionTemplateDetailsArray'
+  /v2/sessiontemplatesvalid/{session_template_id}:
+    parameters:
+      - name: session_template_id
+        in: path
+        description: Session Template ID
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Validate the session template by id
+      description: |
+        Validate session template by session_template_id.
+        The session_template_id corresponds to the *name*
+        of the session template.
+      tags:
+        - v2
+        - sessiontemplatess
+      x-openapi-router-controller: bos.server.controllers.v2.sessiontemplates
+      operationId: validate_v2_sessiontemplate
+      responses:
+        200:
+          $ref: '#/components/responses/V2SessionTemplateValidation'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+  /v2/sessiontemplates/{session_template_id}:
+    parameters:
+      - name: session_template_id
+        in: path
+        description: Session Template ID
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get session template by id
+      description: |
+        Get session template by session_template_id.
+        The session_template_id corresponds to the *name*
+        of the session template.
+      tags:
+        - v2
+        - sessiontemplatess
+      x-openapi-router-controller: bos.server.controllers.v2.sessiontemplates
+      operationId: get_v2_sessiontemplate
+      responses:
+        200:
+          $ref: '#/components/responses/V2SessionTemplateDetails'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+    put:
+      summary: Create session template
+      tags:
+        - v2
+        - sessiontemplates
+      x-openapi-router-controller: bos.server.controllers.v2.sessiontemplates
+      operationId: put_v2_sessiontemplate
+      description:
+        Create a new session template.
+      requestBody:
+         description: A JSON object for creating a session template
+         required: true
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/V2SessionTemplate'
+      responses:
+        200:
+          $ref: '#/components/responses/V2SessionTemplateDetails'
+        400:
+          $ref: '#/components/responses/BadRequest'
+    patch:
+      summary: Update a session template
+      tags:
+        - v2
+        - sessiontemplates
+      x-openapi-router-controller: bos.server.controllers.v2.sessiontemplates
+      operationId: patch_v2_sessiontemplate
+      requestBody:
+        description: A JSON object for updating a session template
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V2SessionTemplate'
+      responses:
+        200:
+          $ref: '#/components/responses/V2SessionTemplateDetails'
+        400:
+          $ref: '#/components/responses/BadRequest'        
+    delete:
+      summary: Delete a session template
+      description: Delete a session template.
+      tags:
+        - v2
+        - sessiontemplates
+      x-openapi-router-controller: bos.server.controllers.v2.sessiontemplates
+      operationId: delete_v2_sessiontemplate
+      responses:
+        204:
+          $ref: '#/components/responses/ResourceDeleted'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+  /v2/sessiontemplatetemplate:
+    get:
+      summary: Get an example session template.
+      description: |
+        Returns a skeleton of a session template, which can be
+        used as a starting point for users creating their own
+        session templates.
+      tags:
+        - v2
+        - sessiontemplates
+      x-openapi-router-controller: bos.server.controllers.v2.sessiontemplates
+      operationId: get_v2_sessiontemplatetemplate
+      responses:
+        200:
+          $ref: '#/components/responses/V2SessionTemplateDetails'
+  /v2/sessions:
+    post:
+      summary: Create a session
+      description: |
+        The creation of a session performs the operation
+        specified in the SessionCreateRequest
+        on the boot set(s) defined in the session template.
+      tags:
+        - v2
+        - sessions
+      x-openapi-router-controller: bos.server.controllers.v2.sessions
+      operationId: post_v2_session
+      requestBody:
+         $ref: '#/components/requestBodies/V2sessionCreateRequest'
+      responses:
+        201:
+          $ref: '#/components/responses/V2SessionDetails'
+        400:
+          $ref: '#/components/responses/BadRequest'
+    get:
+      summary: List sessions
+      description: |
+        List all sessions, including those in progress and those complete.
+      tags:
+        - v2
+        - sessions
+      x-openapi-router-controller: bos.server.controllers.v2.sessions
+      operationId: get_v2_sessions
+      parameters:
+        - name: min_age
+          schema:
+            type: string
+          in: query
+          description: >-
+            Return only sessions older than the given age.  Age is given in the format "1d" or "6h"
+        - name: max_age
+          schema:
+            type: string
+          in: query
+          description: >-
+            Return only sessions younger than the given age.  Age is given in the format "1d" or "6h"
+        - name: status
+          schema:
+            type: string
+            enum: ['pending', 'running', 'complete']
+          in: query
+          description: >-
+            Return only sessions with the given status.
+      responses:
+        200:
+          $ref: '#/components/responses/V2SessionDetailsArray'
+    delete:
+      summary: Delete multiple sessions.
+      tags:
+        - v2
+        - sessions
+      x-openapi-router-controller: bos.server.controllers.v2.sessions
+      operationId: delete_v2_sessions
+      parameters:
+        - name: min_age
+          schema:
+            type: string
+          in: query
+          description: >-
+            Return only sessions older than the given age.  Age is given in the format "1d" or "6h"
+        - name: max_age
+          schema:
+            type: string
+          in: query
+          description: >-
+            Return only sessions younger than the given age.  Age is given in the format "1d" or "6h"
+        - name: status
+          schema:
+            enum: ['pending', 'running', 'complete']
+            type: string
+          in: query
+          description: >-
+            Return only sessions with the given status.
+      description:
+        Delete multiple sessions.  If filters are provided, only sessions matching
+        all filters will be deleted.  By default only completed sessions will be deleted.
+      responses:
+        204:
+          $ref: '#/components/responses/ResourceDeleted'
+        400:
+          $ref: '#/components/responses/BadRequest'
+  /v2/sessions/{session_id}:
+    get:
+      summary: Get session details by id
+      description: Get session details by session_id.
+      tags:
+        - v2
+        - sessions
+      x-openapi-router-controller: bos.server.controllers.v2.sessions
+      operationId: get_v2_session
+      responses:
+        200:
+          $ref: '#/components/responses/V2SessionDetails'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+    patch:
+      summary: Update a single session
+      tags:
+        - v2
+        - sessions
+      x-openapi-router-controller: bos.server.controllers.v2.sessions
+      description: Update the state for a given session in the BOS database
+      operationId: patch_v2_session
+      requestBody:
+        $ref: '#/components/requestBodies/V2sessionUpdateRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/V2SessionDetails'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+    delete:
+      summary: Delete session by id
+      description: Delete session by session_id.
+      tags:
+        - v2
+        - sessions
+      x-openapi-router-controller: bos.server.controllers.v2.sessions
+      operationId: delete_v2_session
+      responses:
+        204:
+          $ref: '#/components/responses/ResourceDeleted'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+    parameters:
+      - name: session_id
+        in: path
+        description: Session ID
+        required: true
+        schema:
+          type: string
+  /v2/sessions/{session_id}/status:
+    get:
+      summary: Get session extended status information by id
+      description: Get session extended status information by id
+      tags:
+        - v2
+        - sessions
+      x-openapi-router-controller: bos.server.controllers.v2.sessions
+      operationId: get_v2_session_status
+      responses:
+        200:
+          $ref: '#/components/responses/V2SessionExtendedStatus'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+    post:
+      summary: Saves the current session to database
+      tags:
+        - v2
+        - sessions
+        - cli_ignore
+      x-openapi-router-controller: bos.server.controllers.v2.sessions
+      description: Saves the current session to database.  For use at session completion.
+      operationId: save_v2_session_status
+      responses:
+        200:
+          $ref: '#/components/responses/V2SessionDetails'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+    parameters:
+      - name: session_id
+        in: path
+        description: Session ID
+        required: true
+        schema:
+          type: string
+  /v2/components:
+    get:
+      summary: Retrieve the state of a collection of components
+      tags:
+        - v2
+        - components
+      x-openapi-router-controller: bos.server.controllers.v2.components
+      description: >-
+        Retrieve the full collection of components in the form of a
+        ComponentArray. Full results can also be filtered by query
+        parameters. Only the first filter parameter of each type is
+        used and the parameters are applied in an AND fashion.
+        If the collection is empty or the filters have no match, an
+        empty array is returned.
+      operationId: get_v2_components
+      parameters:
+        - name: ids
+          schema:
+            type: string
+          in: query
+          description: >-
+            Retrieve the components with the given id
+            (e.g. xname for hardware components). Can be chained
+            for selecting groups of components.
+        - name: session
+          schema:
+            type: string
+          in: query
+          description: >-
+            Retrieve the components with the given session id.
+        - name: staged_session
+          schema:
+            type: string
+          in: query
+          description: >-
+            Retrieve the components with the given staged session id.
+        - name: enabled
+          schema:
+            type: boolean
+          in: query
+          description: >-
+            Retrieve the components with the "enabled" state.
+        - name: phase
+          schema:
+            type: string
+          in: query
+          description: >-
+            Retrieve the components in the given phase.
+        - name: status
+          schema:
+            type: string
+          in: query
+          description: >-
+            Retrieve the components with the given status.
+      responses:
+        200:
+          $ref: '#/components/responses/V2componentDetailsArray'
+        400:
+          $ref: '#/components/responses/BadRequest'
+    put:
+      summary: Add or Replace a collection of components
+      tags:
+        - v2
+        - components
+        - cli_ignore
+      x-openapi-router-controller: bos.server.controllers.v2.components
+      description: Update the state for a collection of components in the BOS database
+      operationId: put_v2_components
+      requestBody:
+        $ref: '#/components/requestBodies/V2componentsPutRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/V2componentDetailsArray'
+        400:
+          $ref: '#/components/responses/BadRequest'
+    patch:
+      summary: Update a collection of components
+      tags:
+        - v2
+        - components
+        - cli_ignore
+      x-openapi-router-controller: bos.server.controllers.v2.components
+      description: Update the state for a collection of components in the BOS database
+      operationId: patch_v2_components
+      requestBody:
+        $ref: '#/components/requestBodies/V2componentsUpdateRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/V2componentDetailsArray'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+  /v2/components/{component_id}:
+    get:
+      summary: Retrieve the state of a single component
+      tags:
+        - v2
+        - components
+      x-openapi-router-controller: bos.server.controllers.v2.components
+      description: Retrieve the current and desired state of a single component
+      operationId: get_v2_component
+      responses:
+        200:
+          $ref: '#/components/responses/V2componentDetails'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+    put:
+      summary: Add or Replace a single component
+      tags:
+        - v2
+        - components
+      x-openapi-router-controller: bos.server.controllers.v2.components
+      description: Update the state for a given component in the BOS database
+      operationId: put_v2_component
+      requestBody:
+        $ref: '#/components/requestBodies/V2componentUpdateRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/V2componentDetails'
+        400:
+          $ref: '#/components/responses/BadRequest'
+    patch:
+      summary: Update a single component
+      tags:
+        - v2
+        - components
+      x-openapi-router-controller: bos.server.controllers.v2.components
+      description: Update the state for a given component in the BOS database
+      operationId: patch_v2_component
+      requestBody:
+        $ref: '#/components/requestBodies/V2componentUpdateRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/V2componentDetails'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+    delete:
+      tags:
+        - v2
+        - components
+        - cli_ignore
+      summary: Delete a single component
+      x-openapi-router-controller: bos.server.controllers.v2.components
+      description: Delete the given component
+      operationId: delete_v2_component
+      responses:
+        204:
+          $ref: '#/components/responses/ResourceDeleted'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+    parameters:
+      - name: component_id
+        in: path
+        description: Component id. e.g. xname for hardware components
+        required: true
+        schema:
+          type: string
+  /v2/applystaged:
+    post:
+      summary: Start a staged session for the specified components
+      description: |
+        Given a list of xnames, this will trigger the start of any sessions
+        staged for those components.  Components without a staged session
+        will be ignored, and a list all components that are acted on will
+        be returned in the response.
+      tags:
+        - v2
+        - applystaged
+      x-openapi-router-controller: bos.server.controllers.v2.components
+      operationId: post_v2_apply_staged
+      requestBody:
+         $ref: '#/components/requestBodies/V2applyStagedRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/V2applyStagedResponse'
+        400:
+          $ref: '#/components/responses/BadRequest'
+  /v2/options:
+    get:
+      summary: Retrieve the BOS service options
+      tags:
+        - options
+      x-openapi-router-controller: bos.server.controllers.v2.options
+      description: Retrieve the list of BOS service options.
+      operationId: get_v2_options
+      responses:
+        200:
+          $ref: '#/components/responses/V2options'
+    patch:
+      summary: Update BOS service options
+      tags:
+        - v2
+        - options
+      x-openapi-router-controller: bos.server.controllers.v2.options
+      operationId: patch_v2_options
+      description: Update one or more of the BOS service options.
+      requestBody:
+        $ref: '#/components/requestBodies/V2optionsUpdateRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/V2options'
+        400:
+          $ref: '#/components/responses/BadRequest'
+  /v2/version:
+    get:
+      summary: Get API version
+      tags:
+        - v2
+        - version
+      x-openapi-router-controller: bos.server.controllers.v2.base
+      operationId: get_version_v2
+      responses:
+        200:
+          $ref: '#/components/responses/Version'
+        500:
+          $ref: '#/components/responses/BadRequest'

--- a/cray/modules/bos/swagger3.json
+++ b/cray/modules/bos/swagger3.json
@@ -2,8 +2,8 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Boot Orchestration Service",
-        "version": "1.5.0",
-        "description": "The Boot Orchestration Service (BOS) applies 1 of 4 possible\nactions (boot, reboot, reconfigure, shutdown) to a list of compute nodes\nusing a specified image (if applicable), with specified kernel parameters,\nover a specified network. Currently, only one network option is available.\nAfter boot or reboot, nodes can be reconfigured.\n\n\nThe default content type for the BOS API is \"application/json\". Unsuccessful\nAPI calls return a content type of \"application/problem+json\" as per RFC 7807.\n\n## Resources\n\n\n### /sessiontemplate\n\nA session template controls the activity of BOS; it is a collection of one or more boot\nsets, combined with partition information, and\nconfiguration detail.\n\nA boot set defines a list of nodes, the image you want to boot/reboot the nodes with,\nkernel parameters to use to boot the nodes, and the network to boot the nodes over.\n\n### /session\n\nA BOS session applies the action to the nodes in the session\ntemplate.\n\n## Workflow\n\n\n### Create a New Session\n\n#### GET /sessiontemplate\n\nList available session templates.\nNote the *name* which uniquely identifies each session template.\nThis value can be used to create a new session later,\nif specified in the request body of POST /session.\n\n#### POST /sessiontemplate\n\nIf no session template pre-exists that satisfies requirements,\nthen create a new session template. *name* uniquely identifies the\nsession template.\nThis value can be used to create a new session later,\nif specified in the request body of POST /session.\n\n#### POST /session\n\nSpecify templateUuid and an\noperation to create a new session.\nThe templateUuid corresponds to the session template *name*.\nA new session is launched as a result of this call.\n\nA limit can also be specified to narrow the scope of the session. The limit\ncan consist of nodes, groups or roles in a comma-seperated list.\nMultiple groups are treated as seperated by OR, unless \"&\" is added to\nthe start of the component, in which case this becomes an AND.  Components\ncan also be preceded by \"!\" to exclude them.\n\nNote, the response from a successful session launch contains *links*.\nWithin *links*, *href* is a string that uniquely identifies the session.\n*href* is constructed using the session template name and a generated uuid.\nUse the entire *href* string as the path parameter *session_id*\nto uniquely identify a session in for the /session/{session_id}\nendpoint.\n\n\n#### GET /session/{session_id}\n\nGet session details by session id.\n\nList all in progress and completed sessions.\n\n\n## Interactions with Other APIs\n\n\nBOS works in concert with Image Management Service (IMS) to access boot images,\nand if *enable_cfs* is true then\nBOS will invoke CFS to configure the compute nodes.\n\n\nAll boot images specified via the session template, must be available via IMS.\n"
+        "version": "0.0.0-api",
+        "description": "The Boot Orchestration Service (BOS) provides coordinated provisioning actions\nover defined hardware sets to enable boot, reboot, shutdown, configuration and\nstaging for specified hardware subsets. These provisioning actions apply state\nthrough numerous system management APIs at the request of system administrators\nfor managed product environments.\n\nThe default content type for the BOS API is \"application/json\". Unsuccessful\nAPI calls return a content type of \"application/problem+json\" as per RFC 7807.\n\n## Resources\n\n\n### /sessiontemplate\n\nA session template sets the operational context of which nodes to operate on for\nany given set of nodes. It is largely comprised of one or more boot\nsets and their associated software configuration.\n\nA boot set defines a list of nodes, the image you want to boot/reboot the nodes with,\nkernel parameters to use to boot the nodes, and additional configuration management\nframework actions to apply during node bring up.\n\n### /session\n\nA BOS session applies a provided action to the nodes defined in a session\ntemplate.\n\n## Workflow\n\n\n### Create a New Session\n\n#### GET /sessiontemplate\n\nList available session templates.\nNote the *name* which uniquely identifies each session template.\nThis value can be used to create a new session later,\nif specified in the request body of POST /session.\n\n#### POST /sessiontemplate\n\nIf no session template pre-exists that satisfies requirements,\nthen create a new session template. *name* uniquely identifies the\nsession template.\nThis value can be used to create a new session later,\nif specified in the request body of POST /session.\n\n#### POST /session\n\nSpecify template_name and an\noperation to create a new session.\nThe template_name corresponds to the session template *name*.\nA new session is launched as a result of this call.\n\nA limit can also be specified to narrow the scope of the session. The limit\ncan consist of nodes, groups or roles in a comma-separated list.\nMultiple groups are treated as separated by OR, unless \"&\" is added to\nthe start of the component, in which case this becomes an AND.  Components\ncan also be preceded by \"!\" to exclude them.\n\nNote, the response from a successful session launch contains *links*.\nWithin *links*, *href* is a string that uniquely identifies the session.\n*href* is constructed using the session template name and a generated uuid.\nUse the entire *href* string as the path parameter *session_id*\nto uniquely identify a session in for the /session/{session_id}\nendpoint.\n\n\n#### GET /session/{session_id}\n\nGet session details by session id.\n\nList all in progress and completed sessions.\n\n\n## Interactions with Other APIs\n\n\nBOS works in concert with Image Management Service (IMS) to access boot images,\nand if *enable_cfs* is true then\nBOS will invoke CFS to configure the compute nodes.\n\n\nAll boot images specified via the session template, must be available via IMS.\n"
     },
     "servers": [
         {
@@ -30,6 +30,69 @@
                 },
                 "additionalProperties": false
             },
+            "Version": {
+                "description": "Version data",
+                "type": "object",
+                "properties": {
+                    "major": {
+                        "type": "integer"
+                    },
+                    "minor": {
+                        "type": "integer"
+                    },
+                    "patch": {
+                        "type": "integer"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "description": "Link to other resources",
+                            "type": "object",
+                            "properties": {
+                                "rel": {
+                                    "type": "string"
+                                },
+                                "href": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ProblemDetails": {
+                "description": "An error response for RFC 7807 problem details.",
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                        "type": "string",
+                        "format": "uri",
+                        "default": "about:blank"
+                    },
+                    "title": {
+                        "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "HTTP status code",
+                        "type": "integer",
+                        "example": 400
+                    },
+                    "instance": {
+                        "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                        "format": "uri",
+                        "type": "string"
+                    },
+                    "detail": {
+                        "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            },
             "Link": {
                 "description": "Link to other resources",
                 "type": "object",
@@ -43,84 +106,7 @@
                 },
                 "additionalProperties": false
             },
-            "BootSet": {
-                "description": "A boot set defines a collection of nodes and the information about the\nboot artifacts and parameters to be sent to each node over the specified\nnetwork to enable these nodes to boot. When multiple boot sets are used\nin a session template, the boot_ordinal and shtudown_ordinal indicate\nthe order in which boot sets need to be acted upon. Boot sets sharing\nthe same ordinal number will be addressed at the same time.\n",
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "The Boot Set name.\n"
-                    },
-                    "boot_ordinal": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "description": "The boot ordinal. This will establish the order for boot set operations.\nBoot sets boot in order from the lowest to highest boot_ordinal.\n"
-                    },
-                    "shutdown_ordinal": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "description": "The shutdown ordinal. This will establish the order for boot set\nshutdown operations. Sets shutdown from low to high shutdown_ordinal.\n"
-                    },
-                    "path": {
-                        "type": "string",
-                        "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
-                    },
-                    "type": {
-                        "type": "string",
-                        "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
-                    },
-                    "etag": {
-                        "type": "string",
-                        "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
-                    },
-                    "kernel_parameters": {
-                        "type": "string",
-                        "description": "The kernel parameters to use to boot the nodes.\n"
-                    },
-                    "network": {
-                        "type": "string",
-                        "description": "The network over which the node will boot from.\nChoices:  NMN -- Node Management Network\npattern: '^(?i)nmn$'\n"
-                    },
-                    "node_list": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "minItems": 1,
-                        "description": "The node list. This is an explicit mapping against hardware xnames.\n"
-                    },
-                    "node_roles_groups": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "minItems": 1,
-                        "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
-                    },
-                    "node_groups": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "minItems": 1,
-                        "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
-                    },
-                    "rootfs_provider": {
-                        "type": "string",
-                        "description": "The root file system provider.\n"
-                    },
-                    "rootfs_provider_passthrough": {
-                        "type": "string",
-                        "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "path",
-                    "type"
-                ]
-            },
-            "CfsParameters": {
+            "V1CfsParameters": {
                 "type": "object",
                 "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled.\n",
                 "properties": {
@@ -147,7 +133,7 @@
                 },
                 "additionalProperties": false
             },
-            "GenericMetadata": {
+            "V1GenericMetadata": {
                 "type": "object",
                 "description": "The status metadata\n",
                 "properties": {
@@ -179,7 +165,7 @@
                 },
                 "additionalProperties": false
             },
-            "NodeList": {
+            "V1NodeList": {
                 "type": "array",
                 "items": {
                     "type": "string",
@@ -189,7 +175,7 @@
                     ]
                 }
             },
-            "PhaseCategoryStatus": {
+            "V1PhaseCategoryStatus": {
                 "type": "object",
                 "description": "A list of the nodes in a given category within a phase.\n\n## Link Relationships\n\n* self : The session object\n",
                 "properties": {
@@ -211,7 +197,7 @@
                     }
                 }
             },
-            "PhaseStatus": {
+            "V1PhaseStatus": {
                 "type": "object",
                 "description": "The phase's status. It is a list of all of the nodes in the phase and\nwhat category those nodes fall into within the phase.\n\n## Link Relationships\n\n* self : The session object\n",
                 "properties": {
@@ -294,7 +280,7 @@
                     }
                 }
             },
-            "BootSetStatus": {
+            "V1BootSetStatus": {
                 "type": "object",
                 "description": "The status for a Boot Set. It as a list of the phase statuses for the Boot Set.\n\n## Link Relationships\n\n* self : The session object\n* phase : A phase of the boot set\n",
                 "properties": {
@@ -445,7 +431,7 @@
                     }
                 }
             },
-            "SessionStatus": {
+            "V1SessionStatus": {
                 "type": "object",
                 "description": "The status for a Boot Session. It is a list of all of the Boot Set Statuses in the session.\n## Link Relationships\n\n* self : The session object\n* boot sets: URL to access the Boot Set status\n",
                 "properties": {
@@ -511,17 +497,90 @@
                     }
                 }
             },
-            "SessionTemplate": {
+            "V1BootSet": {
+                "description": "A boot set defines a collection of nodes and the information about the\nboot artifacts and parameters to be sent to each node over the specified\nnetwork to enable these nodes to boot. When multiple boot sets are used\nin a session template, the boot_ordinal and shtudown_ordinal indicate\nthe order in which boot sets need to be acted upon. Boot sets sharing\nthe same ordinal number will be addressed at the same time.\n",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The Boot Set name.\n"
+                    },
+                    "boot_ordinal": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "The boot ordinal. This will establish the order for boot set operations.\nBoot sets boot in order from the lowest to highest boot_ordinal.\n"
+                    },
+                    "shutdown_ordinal": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "The shutdown ordinal. This will establish the order for boot set\nshutdown operations. Sets shutdown from low to high shutdown_ordinal.\n"
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
+                    },
+                    "etag": {
+                        "type": "string",
+                        "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
+                    },
+                    "kernel_parameters": {
+                        "type": "string",
+                        "description": "The kernel parameters to use to boot the nodes.\n"
+                    },
+                    "network": {
+                        "type": "string",
+                        "description": "The network over which the node will boot from.\nChoices:  NMN -- Node Management Network\npattern: '^(?i)nmn$'\n"
+                    },
+                    "node_list": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "The node list. This is an explicit mapping against hardware xnames.\n"
+                    },
+                    "node_roles_groups": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
+                    },
+                    "node_groups": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
+                    },
+                    "rootfs_provider": {
+                        "type": "string",
+                        "description": "The root file system provider.\n"
+                    },
+                    "rootfs_provider_passthrough": {
+                        "type": "string",
+                        "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "path",
+                    "type"
+                ]
+            },
+            "V1SessionTemplate": {
                 "type": "object",
                 "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which when combined with an\naction (i.e. boot, reconfigure, reboot, shutdown) will create a K8s BOA job\nto complete the required tasks for the operation.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
                 "properties": {
                     "templateUrl": {
                         "type": "string",
-                        "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters (excluding templateBody).\n"
-                    },
-                    "templateBody": {
-                        "type": "string",
-                        "description": "Do not use. To be removed.\n"
+                        "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
                     },
                     "name": {
                         "type": "string",
@@ -682,7 +741,7 @@
                 ],
                 "additionalProperties": false
             },
-            "Session": {
+            "V1Session": {
                 "description": "A Session object\n\n## Link Relationships\n\n* self : The session object\n",
                 "type": "object",
                 "properties": {
@@ -693,13 +752,26 @@
                     },
                     "templateUuid": {
                         "type": "string",
+                        "description": "DEPRECATED - use templateName",
+                        "example": "my-session-template",
+                        "format": "string"
+                    },
+                    "templateName": {
+                        "type": "string",
                         "description": "The name of the Session Template",
                         "example": "my-session-template",
                         "format": "string"
                     },
+                    "job": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "readOnly": true,
+                        "description": "The identity of the k8s job that is created to handle the session.\n",
+                        "example": "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
+                    },
                     "limit": {
                         "type": "string",
-                        "description": "A comma seperated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                        "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
                     },
                     "links": {
                         "type": "array",
@@ -720,44 +792,11 @@
                     }
                 },
                 "required": [
-                    "operation",
-                    "templateUuid"
+                    "operation"
                 ],
                 "additionalProperties": false
             },
-            "Version": {
-                "description": "Version data",
-                "type": "object",
-                "properties": {
-                    "major": {
-                        "type": "integer"
-                    },
-                    "minor": {
-                        "type": "integer"
-                    },
-                    "patch": {
-                        "type": "integer"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "description": "Link to other resources",
-                            "type": "object",
-                            "properties": {
-                                "rel": {
-                                    "type": "string"
-                                },
-                                "href": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    }
-                },
-                "additionalProperties": false
-            },
-            "NodeChangeList": {
+            "V1NodeChangeList": {
                 "type": "object",
                 "description": "The information used to update the status of a node list. It moves nodes from\none category to another within a phase.\n",
                 "properties": {
@@ -792,7 +831,7 @@
                     "node_list"
                 ]
             },
-            "NodeErrorsList": {
+            "V1NodeErrorsList": {
                 "type": "object",
                 "description": "Categorizing nodes into failures by the type of error they have.\nThis is an additive characterization. Nodes will be added to existing errors.\nThis does not overwrite previously existing errors.\n",
                 "additionalProperties": {
@@ -806,7 +845,7 @@
                     }
                 }
             },
-            "UpdateRequestNodeChangeList": {
+            "V1UpdateRequestNodeChangeList": {
                 "description": "This is the payload sent during an update request. It contains\nupdates to which categories nodes are in.\n",
                 "type": "array",
                 "items": {
@@ -860,7 +899,7 @@
                     }
                 }
             },
-            "UpdateRequestNodeErrorsList": {
+            "V1UpdateRequestNodeErrorsList": {
                 "description": "This is the payload sent during an update request. It contains\nupdates to which errors have occurred and which nodes encountered those errors\n",
                 "type": "array",
                 "items": {
@@ -893,7 +932,7 @@
                     }
                 }
             },
-            "UpdateRequestGenericMetadata": {
+            "V1UpdateRequestGenericMetadata": {
                 "description": "This is the payload sent during an update request. It contains\nupdates to metadata, specifically start and stop times\n",
                 "type": "array",
                 "items": {
@@ -944,69 +983,2541 @@
                     }
                 }
             },
-            "ProblemDetails": {
-                "description": "An error response for RFC 7807 problem details.",
+            "V2CfsParameters": {
                 "type": "object",
+                "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
                 "properties": {
-                    "type": {
-                        "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                    "configuration": {
                         "type": "string",
-                        "format": "uri",
-                        "default": "about:blank"
-                    },
-                    "title": {
-                        "description": "Short, human-readable summary of the problem, should not change by occurrence.",
-                        "type": "string"
-                    },
-                    "status": {
-                        "description": "HTTP status code",
-                        "type": "integer",
-                        "example": 400
-                    },
-                    "instance": {
-                        "description": "A relative URI reference that identifies the specific occurrence of the problem",
-                        "format": "uri",
-                        "type": "string"
-                    },
-                    "detail": {
-                        "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
-                        "type": "string"
+                        "description": "The name of configuration to be applied.\n"
                     }
                 },
                 "additionalProperties": false
+            },
+            "V2SessionTemplate": {
+                "type": "object",
+                "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which applies the data to\ngroup of components.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
+                        "example": "cle-1.0.0",
+                        "minLength": 1,
+                        "maxLength": 45,
+                        "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
+                        "readOnly": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "An optional description for the session template.\n"
+                    },
+                    "enable_cfs": {
+                        "type": "boolean",
+                        "description": "Whether to enable the Configuration Framework Service (CFS).\nChoices: true/false\n",
+                        "default": true
+                    },
+                    "cfs": {
+                        "type": "object",
+                        "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                        "properties": {
+                            "configuration": {
+                                "type": "string",
+                                "description": "The name of configuration to be applied.\n"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "boot_sets": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "description": "A boot set is a collection of nodes defined by an explicit list, their functional\nrole, and their logical groupings. This collection of nodes is associated with one\nset of boot artifacts and optional additional records for configuration and root\nfilesystem provisioning.\n",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "The Boot Set name.\n"
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
+                                },
+                                "cfs": {
+                                    "type": "object",
+                                    "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                    "properties": {
+                                        "configuration": {
+                                            "type": "string",
+                                            "description": "The name of configuration to be applied.\n"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "type": {
+                                    "type": "string",
+                                    "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
+                                },
+                                "etag": {
+                                    "type": "string",
+                                    "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
+                                },
+                                "kernel_parameters": {
+                                    "type": "string",
+                                    "description": "The kernel parameters to use to boot the nodes.\n"
+                                },
+                                "node_list": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "minItems": 1,
+                                    "description": "The node list. This is an explicit mapping against hardware xnames.\n"
+                                },
+                                "node_roles_groups": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "minItems": 1,
+                                    "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
+                                },
+                                "node_groups": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "minItems": 1,
+                                    "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
+                                },
+                                "rootfs_provider": {
+                                    "type": "string",
+                                    "description": "The root file system provider.\n"
+                                },
+                                "rootfs_provider_passthrough": {
+                                    "type": "string",
+                                    "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "path",
+                                "type"
+                            ]
+                        }
+                    },
+                    "links": {
+                        "type": "array",
+                        "readOnly": true,
+                        "items": {
+                            "description": "Link to other resources",
+                            "type": "object",
+                            "properties": {
+                                "rel": {
+                                    "type": "string"
+                                },
+                                "href": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "required": [],
+                "additionalProperties": false
+            },
+            "V2SessionTemplateArray": {
+                "description": "An array of session templates.",
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which applies the data to\ngroup of components.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
+                            "example": "cle-1.0.0",
+                            "minLength": 1,
+                            "maxLength": 45,
+                            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
+                            "readOnly": true
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "An optional description for the session template.\n"
+                        },
+                        "enable_cfs": {
+                            "type": "boolean",
+                            "description": "Whether to enable the Configuration Framework Service (CFS).\nChoices: true/false\n",
+                            "default": true
+                        },
+                        "cfs": {
+                            "type": "object",
+                            "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                            "properties": {
+                                "configuration": {
+                                    "type": "string",
+                                    "description": "The name of configuration to be applied.\n"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "boot_sets": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "description": "A boot set is a collection of nodes defined by an explicit list, their functional\nrole, and their logical groupings. This collection of nodes is associated with one\nset of boot artifacts and optional additional records for configuration and root\nfilesystem provisioning.\n",
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The Boot Set name.\n"
+                                    },
+                                    "path": {
+                                        "type": "string",
+                                        "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
+                                    },
+                                    "cfs": {
+                                        "type": "object",
+                                        "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                        "properties": {
+                                            "configuration": {
+                                                "type": "string",
+                                                "description": "The name of configuration to be applied.\n"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
+                                    },
+                                    "etag": {
+                                        "type": "string",
+                                        "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
+                                    },
+                                    "kernel_parameters": {
+                                        "type": "string",
+                                        "description": "The kernel parameters to use to boot the nodes.\n"
+                                    },
+                                    "node_list": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "minItems": 1,
+                                        "description": "The node list. This is an explicit mapping against hardware xnames.\n"
+                                    },
+                                    "node_roles_groups": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "minItems": 1,
+                                        "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
+                                    },
+                                    "node_groups": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "minItems": 1,
+                                        "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
+                                    },
+                                    "rootfs_provider": {
+                                        "type": "string",
+                                        "description": "The root file system provider.\n"
+                                    },
+                                    "rootfs_provider_passthrough": {
+                                        "type": "string",
+                                        "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
+                                    }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                    "path",
+                                    "type"
+                                ]
+                            }
+                        },
+                        "links": {
+                            "type": "array",
+                            "readOnly": true,
+                            "items": {
+                                "description": "Link to other resources",
+                                "type": "object",
+                                "properties": {
+                                    "rel": {
+                                        "type": "string"
+                                    },
+                                    "href": {
+                                        "type": "string"
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "required": [],
+                    "additionalProperties": false
+                }
+            },
+            "V2SessionTemplateValidation": {
+                "description": "Message describing errors or incompleteness in a Session Template.\n",
+                "type": "string"
+            },
+            "V2SessionCreate": {
+                "description": "A Session Creation object\n",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the session. A uuid name is generated if a name is not provided.",
+                        "example": "session-20190728032600",
+                        "minLength": 1,
+                        "maxLength": 45,
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                    },
+                    "operation": {
+                        "type": "string",
+                        "enum": [
+                            "boot",
+                            "reboot",
+                            "shutdown"
+                        ],
+                        "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                    },
+                    "template_name": {
+                        "type": "string",
+                        "description": "The name of the Session Template",
+                        "example": "my-session-template",
+                        "format": "string"
+                    },
+                    "limit": {
+                        "type": "string",
+                        "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                    },
+                    "stage": {
+                        "type": "boolean",
+                        "description": "Set to force nodes to reboot even if they are already in the desired state.\n",
+                        "default": false
+                    }
+                },
+                "required": [
+                    "operation",
+                    "template_name"
+                ],
+                "additionalProperties": false
+            },
+            "V2SessionStatus": {
+                "type": "object",
+                "description": "Information on the status of a session.\n",
+                "properties": {
+                    "start_time": {
+                        "type": "string",
+                        "description": "When the session was created.\n"
+                    },
+                    "end_time": {
+                        "type": "string",
+                        "description": "When the session completed.\n"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "pending",
+                            "running",
+                            "complete"
+                        ],
+                        "description": "The status of a session.\n"
+                    },
+                    "error": {
+                        "type": "string",
+                        "description": "Error which prevented the session from running\n"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2BootSet": {
+                "description": "A boot set is a collection of nodes defined by an explicit list, their functional\nrole, and their logical groupings. This collection of nodes is associated with one\nset of boot artifacts and optional additional records for configuration and root\nfilesystem provisioning.\n",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The Boot Set name.\n"
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
+                    },
+                    "cfs": {
+                        "type": "object",
+                        "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                        "properties": {
+                            "configuration": {
+                                "type": "string",
+                                "description": "The name of configuration to be applied.\n"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
+                    },
+                    "etag": {
+                        "type": "string",
+                        "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
+                    },
+                    "kernel_parameters": {
+                        "type": "string",
+                        "description": "The kernel parameters to use to boot the nodes.\n"
+                    },
+                    "node_list": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "The node list. This is an explicit mapping against hardware xnames.\n"
+                    },
+                    "node_roles_groups": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
+                    },
+                    "node_groups": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
+                    },
+                    "rootfs_provider": {
+                        "type": "string",
+                        "description": "The root file system provider.\n"
+                    },
+                    "rootfs_provider_passthrough": {
+                        "type": "string",
+                        "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "path",
+                    "type"
+                ]
+            },
+            "V2Session": {
+                "description": "A Session object\n\n## Link Relationships\n\n* self : The session object\n",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the session.\n"
+                    },
+                    "operation": {
+                        "type": "string",
+                        "enum": [
+                            "boot",
+                            "reboot",
+                            "shutdown"
+                        ],
+                        "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                    },
+                    "template_name": {
+                        "type": "string",
+                        "description": "The name of the Session Template",
+                        "example": "my-session-template",
+                        "format": "string"
+                    },
+                    "limit": {
+                        "type": "string",
+                        "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                    },
+                    "stage": {
+                        "type": "boolean",
+                        "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                    },
+                    "components": {
+                        "type": "string",
+                        "description": "A comma separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
+                    },
+                    "status": {
+                        "type": "object",
+                        "description": "Information on the status of a session.\n",
+                        "properties": {
+                            "start_time": {
+                                "type": "string",
+                                "description": "When the session was created.\n"
+                            },
+                            "end_time": {
+                                "type": "string",
+                                "description": "When the session completed.\n"
+                            },
+                            "status": {
+                                "type": "string",
+                                "enum": [
+                                    "pending",
+                                    "running",
+                                    "complete"
+                                ],
+                                "description": "The status of a session.\n"
+                            },
+                            "error": {
+                                "type": "string",
+                                "description": "Error which prevented the session from running\n"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2SessionArray": {
+                "description": "An array of sessions.",
+                "type": "array",
+                "items": {
+                    "description": "A Session object\n\n## Link Relationships\n\n* self : The session object\n",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the session.\n"
+                        },
+                        "operation": {
+                            "type": "string",
+                            "enum": [
+                                "boot",
+                                "reboot",
+                                "shutdown"
+                            ],
+                            "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                        },
+                        "template_name": {
+                            "type": "string",
+                            "description": "The name of the Session Template",
+                            "example": "my-session-template",
+                            "format": "string"
+                        },
+                        "limit": {
+                            "type": "string",
+                            "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                        },
+                        "stage": {
+                            "type": "boolean",
+                            "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                        },
+                        "components": {
+                            "type": "string",
+                            "description": "A comma separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
+                        },
+                        "status": {
+                            "type": "object",
+                            "description": "Information on the status of a session.\n",
+                            "properties": {
+                                "start_time": {
+                                    "type": "string",
+                                    "description": "When the session was created.\n"
+                                },
+                                "end_time": {
+                                    "type": "string",
+                                    "description": "When the session completed.\n"
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "enum": [
+                                        "pending",
+                                        "running",
+                                        "complete"
+                                    ],
+                                    "description": "The status of a session.\n"
+                                },
+                                "error": {
+                                    "type": "string",
+                                    "description": "Error which prevented the session from running\n"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "V2SessionExtendedStatusPhases": {
+                "type": "object",
+                "description": "Detailed information on the phases of a session.\n",
+                "properties": {
+                    "percent_complete": {
+                        "type": "float",
+                        "description": "The percent of components currently in a completed/stable state\n"
+                    },
+                    "percent_powering_on": {
+                        "type": "float",
+                        "description": "The percent of components currently in the powering-on phase\n"
+                    },
+                    "percent_powering_off": {
+                        "type": "float",
+                        "description": "The percent of components currently in the powering-off phase\n"
+                    },
+                    "percent_configuring": {
+                        "type": "float",
+                        "description": "The percent of components currently in the configuring phase\n"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2SessionExtendedStatusTiming": {
+                "type": "object",
+                "description": "Detailed information on the timing of a session.\n",
+                "properties": {
+                    "start_time": {
+                        "type": "string",
+                        "description": "When the session was created.\n"
+                    },
+                    "end_time": {
+                        "type": "string",
+                        "description": "When the session completed.\n"
+                    },
+                    "duration": {
+                        "type": "string",
+                        "description": "The current duration of the on-going session or final duration of the completed session.\n"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2SessionExtendedStatus": {
+                "type": "object",
+                "description": "Detailed information on the status of a session.\n",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "pending",
+                            "running",
+                            "complete"
+                        ],
+                        "description": "The status of a session.\n"
+                    },
+                    "managed_components_count": {
+                        "type": "integer",
+                        "description": "The count of components currently managed by this session\n"
+                    },
+                    "phases": {
+                        "type": "object",
+                        "description": "Detailed information on the phases of a session.\n",
+                        "properties": {
+                            "percent_complete": {
+                                "type": "float",
+                                "description": "The percent of components currently in a completed/stable state\n"
+                            },
+                            "percent_powering_on": {
+                                "type": "float",
+                                "description": "The percent of components currently in the powering-on phase\n"
+                            },
+                            "percent_powering_off": {
+                                "type": "float",
+                                "description": "The percent of components currently in the powering-off phase\n"
+                            },
+                            "percent_configuring": {
+                                "type": "float",
+                                "description": "The percent of components currently in the configuring phase\n"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "percent_successful": {
+                        "type": "float",
+                        "description": "The percent of components currently in a successful state\n"
+                    },
+                    "percent_failed": {
+                        "type": "float",
+                        "description": "The percent of components currently in a failed state\n"
+                    },
+                    "percent_staged": {
+                        "type": "float",
+                        "description": "The percent of components currently still staged for this session\n"
+                    },
+                    "error_summary": {
+                        "type": "object",
+                        "description": "A summary of the errors currently listed by all components\n"
+                    },
+                    "timing": {
+                        "type": "object",
+                        "description": "Detailed information on the timing of a session.\n",
+                        "properties": {
+                            "start_time": {
+                                "type": "string",
+                                "description": "When the session was created.\n"
+                            },
+                            "end_time": {
+                                "type": "string",
+                                "description": "When the session completed.\n"
+                            },
+                            "duration": {
+                                "type": "string",
+                                "description": "The current duration of the on-going session or final duration of the completed session.\n"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2BootArtifacts": {
+                "description": "A collection of boot artifacts.\n",
+                "type": "object",
+                "properties": {
+                    "kernel": {
+                        "type": "string",
+                        "description": "An md5sum hash of the kernel ID"
+                    },
+                    "kernel_parameters": {
+                        "type": "string",
+                        "description": "Kernel parameters"
+                    },
+                    "initrd": {
+                        "type": "string",
+                        "description": "Initrd ID"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2ComponentActualState": {
+                "description": "The desired boot artifacts and configuration for a component\n",
+                "type": "object",
+                "properties": {
+                    "boot_artifacts": {
+                        "description": "A collection of boot artifacts.\n",
+                        "type": "object",
+                        "properties": {
+                            "kernel": {
+                                "type": "string",
+                                "description": "An md5sum hash of the kernel ID"
+                            },
+                            "kernel_parameters": {
+                                "type": "string",
+                                "description": "Kernel parameters"
+                            },
+                            "initrd": {
+                                "type": "string",
+                                "description": "Initrd ID"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "bss_token": {
+                        "type": "string",
+                        "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                    },
+                    "last_updated": {
+                        "type": "string",
+                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                        "example": "2019-07-28T03:26:00Z",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
+            "V2ComponentDesiredState": {
+                "description": "The desired boot artifacts and configuration for a component\n",
+                "type": "object",
+                "properties": {
+                    "boot_artifacts": {
+                        "description": "A collection of boot artifacts.\n",
+                        "type": "object",
+                        "properties": {
+                            "kernel": {
+                                "type": "string",
+                                "description": "An md5sum hash of the kernel ID"
+                            },
+                            "kernel_parameters": {
+                                "type": "string",
+                                "description": "Kernel parameters"
+                            },
+                            "initrd": {
+                                "type": "string",
+                                "description": "Initrd ID"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "configuration": {
+                        "type": "string",
+                        "description": "A CFS configuration ID."
+                    },
+                    "bss_token": {
+                        "type": "string",
+                        "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                    },
+                    "last_updated": {
+                        "type": "string",
+                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                        "example": "2019-07-28T03:26:00Z",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2ComponentStagedState": {
+                "description": "The desired boot artifacts and configuration for a component\n",
+                "type": "object",
+                "properties": {
+                    "boot_artifacts": {
+                        "description": "A collection of boot artifacts.\n",
+                        "type": "object",
+                        "properties": {
+                            "kernel": {
+                                "type": "string",
+                                "description": "An md5sum hash of the kernel ID"
+                            },
+                            "kernel_parameters": {
+                                "type": "string",
+                                "description": "Kernel parameters"
+                            },
+                            "initrd": {
+                                "type": "string",
+                                "description": "Initrd ID"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "configuration": {
+                        "type": "string",
+                        "description": "A CFS configuration ID."
+                    },
+                    "session": {
+                        "type": "string",
+                        "description": "A session which can be triggered at a later time against this component."
+                    },
+                    "last_updated": {
+                        "type": "string",
+                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                        "example": "2019-07-28T03:26:00Z",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2ComponentLastAction": {
+                "description": "Information on the most recent action taken against the node.\n",
+                "type": "object",
+                "properties": {
+                    "last_updated": {
+                        "type": "string",
+                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                        "example": "2019-07-28T03:26:00Z",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "action": {
+                        "type": "string",
+                        "description": "A description of the most recent operator/action to impact the component."
+                    },
+                    "num_attempts": {
+                        "type": "integer",
+                        "description": "How many attempts have been made for this action."
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2ComponentStatus": {
+                "description": "Status information for the component",
+                "type": "object",
+                "properties": {
+                    "phase": {
+                        "type": "string",
+                        "description": "The current phase of the component in the boot process."
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "The current status of the component.  More detailed than phase.",
+                        "readOnly": true
+                    },
+                    "status_override": {
+                        "type": "string",
+                        "description": "If set, this will override the status value."
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2Component": {
+                "description": "The current and desired artifacts state for a component.\n",
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The component's id. e.g. xname for hardware components"
+                    },
+                    "actual_state": {
+                        "description": "The desired boot artifacts and configuration for a component\n",
+                        "type": "object",
+                        "properties": {
+                            "boot_artifacts": {
+                                "description": "A collection of boot artifacts.\n",
+                                "type": "object",
+                                "properties": {
+                                    "kernel": {
+                                        "type": "string",
+                                        "description": "An md5sum hash of the kernel ID"
+                                    },
+                                    "kernel_parameters": {
+                                        "type": "string",
+                                        "description": "Kernel parameters"
+                                    },
+                                    "initrd": {
+                                        "type": "string",
+                                        "description": "Initrd ID"
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "bss_token": {
+                                "type": "string",
+                                "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                            },
+                            "last_updated": {
+                                "type": "string",
+                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                "example": "2019-07-28T03:26:00Z",
+                                "format": "date-time",
+                                "readOnly": true
+                            }
+                        }
+                    },
+                    "desired_state": {
+                        "description": "The desired boot artifacts and configuration for a component\n",
+                        "type": "object",
+                        "properties": {
+                            "boot_artifacts": {
+                                "description": "A collection of boot artifacts.\n",
+                                "type": "object",
+                                "properties": {
+                                    "kernel": {
+                                        "type": "string",
+                                        "description": "An md5sum hash of the kernel ID"
+                                    },
+                                    "kernel_parameters": {
+                                        "type": "string",
+                                        "description": "Kernel parameters"
+                                    },
+                                    "initrd": {
+                                        "type": "string",
+                                        "description": "Initrd ID"
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "configuration": {
+                                "type": "string",
+                                "description": "A CFS configuration ID."
+                            },
+                            "bss_token": {
+                                "type": "string",
+                                "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                            },
+                            "last_updated": {
+                                "type": "string",
+                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                "example": "2019-07-28T03:26:00Z",
+                                "format": "date-time",
+                                "readOnly": true
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "staged_state": {
+                        "description": "The desired boot artifacts and configuration for a component\n",
+                        "type": "object",
+                        "properties": {
+                            "boot_artifacts": {
+                                "description": "A collection of boot artifacts.\n",
+                                "type": "object",
+                                "properties": {
+                                    "kernel": {
+                                        "type": "string",
+                                        "description": "An md5sum hash of the kernel ID"
+                                    },
+                                    "kernel_parameters": {
+                                        "type": "string",
+                                        "description": "Kernel parameters"
+                                    },
+                                    "initrd": {
+                                        "type": "string",
+                                        "description": "Initrd ID"
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "configuration": {
+                                "type": "string",
+                                "description": "A CFS configuration ID."
+                            },
+                            "session": {
+                                "type": "string",
+                                "description": "A session which can be triggered at a later time against this component."
+                            },
+                            "last_updated": {
+                                "type": "string",
+                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                "example": "2019-07-28T03:26:00Z",
+                                "format": "date-time",
+                                "readOnly": true
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "last_action": {
+                        "description": "Information on the most recent action taken against the node.\n",
+                        "type": "object",
+                        "properties": {
+                            "last_updated": {
+                                "type": "string",
+                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                "example": "2019-07-28T03:26:00Z",
+                                "format": "date-time",
+                                "readOnly": true
+                            },
+                            "action": {
+                                "type": "string",
+                                "description": "A description of the most recent operator/action to impact the component."
+                            },
+                            "num_attempts": {
+                                "type": "integer",
+                                "description": "How many attempts have been made for this action."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "status": {
+                        "description": "Status information for the component",
+                        "type": "object",
+                        "properties": {
+                            "phase": {
+                                "type": "string",
+                                "description": "The current phase of the component in the boot process."
+                            },
+                            "status": {
+                                "type": "string",
+                                "description": "The current status of the component.  More detailed than phase.",
+                                "readOnly": true
+                            },
+                            "status_override": {
+                                "type": "string",
+                                "description": "If set, this will override the status value."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "enabled": {
+                        "type": "boolean",
+                        "description": "A flag indicating if actions should be taken for this component."
+                    },
+                    "error": {
+                        "type": "string",
+                        "description": "A description of the most recent error to impact the component."
+                    },
+                    "session": {
+                        "type": "string",
+                        "description": "The session responsible for the component's current state"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2ComponentArray": {
+                "description": "An array of component states.",
+                "type": "array",
+                "items": {
+                    "description": "The current and desired artifacts state for a component.\n",
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "The component's id. e.g. xname for hardware components"
+                        },
+                        "actual_state": {
+                            "description": "The desired boot artifacts and configuration for a component\n",
+                            "type": "object",
+                            "properties": {
+                                "boot_artifacts": {
+                                    "description": "A collection of boot artifacts.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "kernel": {
+                                            "type": "string",
+                                            "description": "An md5sum hash of the kernel ID"
+                                        },
+                                        "kernel_parameters": {
+                                            "type": "string",
+                                            "description": "Kernel parameters"
+                                        },
+                                        "initrd": {
+                                            "type": "string",
+                                            "description": "Initrd ID"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "bss_token": {
+                                    "type": "string",
+                                    "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                },
+                                "last_updated": {
+                                    "type": "string",
+                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                    "example": "2019-07-28T03:26:00Z",
+                                    "format": "date-time",
+                                    "readOnly": true
+                                }
+                            }
+                        },
+                        "desired_state": {
+                            "description": "The desired boot artifacts and configuration for a component\n",
+                            "type": "object",
+                            "properties": {
+                                "boot_artifacts": {
+                                    "description": "A collection of boot artifacts.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "kernel": {
+                                            "type": "string",
+                                            "description": "An md5sum hash of the kernel ID"
+                                        },
+                                        "kernel_parameters": {
+                                            "type": "string",
+                                            "description": "Kernel parameters"
+                                        },
+                                        "initrd": {
+                                            "type": "string",
+                                            "description": "Initrd ID"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "configuration": {
+                                    "type": "string",
+                                    "description": "A CFS configuration ID."
+                                },
+                                "bss_token": {
+                                    "type": "string",
+                                    "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                },
+                                "last_updated": {
+                                    "type": "string",
+                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                    "example": "2019-07-28T03:26:00Z",
+                                    "format": "date-time",
+                                    "readOnly": true
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "staged_state": {
+                            "description": "The desired boot artifacts and configuration for a component\n",
+                            "type": "object",
+                            "properties": {
+                                "boot_artifacts": {
+                                    "description": "A collection of boot artifacts.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "kernel": {
+                                            "type": "string",
+                                            "description": "An md5sum hash of the kernel ID"
+                                        },
+                                        "kernel_parameters": {
+                                            "type": "string",
+                                            "description": "Kernel parameters"
+                                        },
+                                        "initrd": {
+                                            "type": "string",
+                                            "description": "Initrd ID"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "configuration": {
+                                    "type": "string",
+                                    "description": "A CFS configuration ID."
+                                },
+                                "session": {
+                                    "type": "string",
+                                    "description": "A session which can be triggered at a later time against this component."
+                                },
+                                "last_updated": {
+                                    "type": "string",
+                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                    "example": "2019-07-28T03:26:00Z",
+                                    "format": "date-time",
+                                    "readOnly": true
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "last_action": {
+                            "description": "Information on the most recent action taken against the node.\n",
+                            "type": "object",
+                            "properties": {
+                                "last_updated": {
+                                    "type": "string",
+                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                    "example": "2019-07-28T03:26:00Z",
+                                    "format": "date-time",
+                                    "readOnly": true
+                                },
+                                "action": {
+                                    "type": "string",
+                                    "description": "A description of the most recent operator/action to impact the component."
+                                },
+                                "num_attempts": {
+                                    "type": "integer",
+                                    "description": "How many attempts have been made for this action."
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "status": {
+                            "description": "Status information for the component",
+                            "type": "object",
+                            "properties": {
+                                "phase": {
+                                    "type": "string",
+                                    "description": "The current phase of the component in the boot process."
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "description": "The current status of the component.  More detailed than phase.",
+                                    "readOnly": true
+                                },
+                                "status_override": {
+                                    "type": "string",
+                                    "description": "If set, this will override the status value."
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "A flag indicating if actions should be taken for this component."
+                        },
+                        "error": {
+                            "type": "string",
+                            "description": "A description of the most recent error to impact the component."
+                        },
+                        "session": {
+                            "type": "string",
+                            "description": "The session responsible for the component's current state"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "V2ComponentsFilter": {
+                "description": "Information for patching multiple components.",
+                "type": "object",
+                "properties": {
+                    "ids": {
+                        "type": "string",
+                        "description": "A comma separated list of component ids"
+                    },
+                    "session": {
+                        "type": "string",
+                        "description": "A session name.  All components part of this session will be patched."
+                    }
+                }
+            },
+            "V2ComponentsUpdate": {
+                "description": "Information for patching multiple components.",
+                "type": "object",
+                "properties": {
+                    "patch": {
+                        "description": "The current and desired artifacts state for a component.\n",
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "The component's id. e.g. xname for hardware components"
+                            },
+                            "actual_state": {
+                                "description": "The desired boot artifacts and configuration for a component\n",
+                                "type": "object",
+                                "properties": {
+                                    "boot_artifacts": {
+                                        "description": "A collection of boot artifacts.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "kernel": {
+                                                "type": "string",
+                                                "description": "An md5sum hash of the kernel ID"
+                                            },
+                                            "kernel_parameters": {
+                                                "type": "string",
+                                                "description": "Kernel parameters"
+                                            },
+                                            "initrd": {
+                                                "type": "string",
+                                                "description": "Initrd ID"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "bss_token": {
+                                        "type": "string",
+                                        "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                    },
+                                    "last_updated": {
+                                        "type": "string",
+                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                        "example": "2019-07-28T03:26:00Z",
+                                        "format": "date-time",
+                                        "readOnly": true
+                                    }
+                                }
+                            },
+                            "desired_state": {
+                                "description": "The desired boot artifacts and configuration for a component\n",
+                                "type": "object",
+                                "properties": {
+                                    "boot_artifacts": {
+                                        "description": "A collection of boot artifacts.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "kernel": {
+                                                "type": "string",
+                                                "description": "An md5sum hash of the kernel ID"
+                                            },
+                                            "kernel_parameters": {
+                                                "type": "string",
+                                                "description": "Kernel parameters"
+                                            },
+                                            "initrd": {
+                                                "type": "string",
+                                                "description": "Initrd ID"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "configuration": {
+                                        "type": "string",
+                                        "description": "A CFS configuration ID."
+                                    },
+                                    "bss_token": {
+                                        "type": "string",
+                                        "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                    },
+                                    "last_updated": {
+                                        "type": "string",
+                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                        "example": "2019-07-28T03:26:00Z",
+                                        "format": "date-time",
+                                        "readOnly": true
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "staged_state": {
+                                "description": "The desired boot artifacts and configuration for a component\n",
+                                "type": "object",
+                                "properties": {
+                                    "boot_artifacts": {
+                                        "description": "A collection of boot artifacts.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "kernel": {
+                                                "type": "string",
+                                                "description": "An md5sum hash of the kernel ID"
+                                            },
+                                            "kernel_parameters": {
+                                                "type": "string",
+                                                "description": "Kernel parameters"
+                                            },
+                                            "initrd": {
+                                                "type": "string",
+                                                "description": "Initrd ID"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "configuration": {
+                                        "type": "string",
+                                        "description": "A CFS configuration ID."
+                                    },
+                                    "session": {
+                                        "type": "string",
+                                        "description": "A session which can be triggered at a later time against this component."
+                                    },
+                                    "last_updated": {
+                                        "type": "string",
+                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                        "example": "2019-07-28T03:26:00Z",
+                                        "format": "date-time",
+                                        "readOnly": true
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "last_action": {
+                                "description": "Information on the most recent action taken against the node.\n",
+                                "type": "object",
+                                "properties": {
+                                    "last_updated": {
+                                        "type": "string",
+                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                        "example": "2019-07-28T03:26:00Z",
+                                        "format": "date-time",
+                                        "readOnly": true
+                                    },
+                                    "action": {
+                                        "type": "string",
+                                        "description": "A description of the most recent operator/action to impact the component."
+                                    },
+                                    "num_attempts": {
+                                        "type": "integer",
+                                        "description": "How many attempts have been made for this action."
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "status": {
+                                "description": "Status information for the component",
+                                "type": "object",
+                                "properties": {
+                                    "phase": {
+                                        "type": "string",
+                                        "description": "The current phase of the component in the boot process."
+                                    },
+                                    "status": {
+                                        "type": "string",
+                                        "description": "The current status of the component.  More detailed than phase.",
+                                        "readOnly": true
+                                    },
+                                    "status_override": {
+                                        "type": "string",
+                                        "description": "If set, this will override the status value."
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "enabled": {
+                                "type": "boolean",
+                                "description": "A flag indicating if actions should be taken for this component."
+                            },
+                            "error": {
+                                "type": "string",
+                                "description": "A description of the most recent error to impact the component."
+                            },
+                            "session": {
+                                "type": "string",
+                                "description": "The session responsible for the component's current state"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "filters": {
+                        "description": "Information for patching multiple components.",
+                        "type": "object",
+                        "properties": {
+                            "ids": {
+                                "type": "string",
+                                "description": "A comma separated list of component ids"
+                            },
+                            "session": {
+                                "type": "string",
+                                "description": "A session name.  All components part of this session will be patched."
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "patch",
+                    "filters"
+                ]
+            },
+            "V2ApplyStagedComponents": {
+                "description": "A list of components that should have their staged session applied.\n",
+                "type": "object",
+                "properties": {
+                    "xnames": {
+                        "description": "The list of component xnames",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2ApplyStagedStatus": {
+                "description": "A list of components that should have their staged session applied.\n",
+                "type": "object",
+                "properties": {
+                    "succeeded": {
+                        "description": "The list of component xnames",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "failed": {
+                        "description": "The list of component xnames",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "ignored": {
+                        "description": "The list of component xnames",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2Options": {
+                "description": "Options for the boot orchestration service.\n",
+                "type": "object",
+                "properties": {
+                    "cleanup_completed_session_ttl": {
+                        "type": "string",
+                        "description": "Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior."
+                    },
+                    "component_actual_state_ttl": {
+                        "type": "string",
+                        "description": "The maximum amount of time a component's actual state is considered valid (in hours). 0h disables cleanup behavior for newly booted nodes and instructs bos-state-reporter to report once instead of periodically."
+                    },
+                    "disable_components_on_completion": {
+                        "type": "boolean",
+                        "description": "Allows for BOS components to be marked as disabled after a session has been completed. If false, BOS will continue to maintain the state of the nodes declaratively, even after a session finishes."
+                    },
+                    "discovery_frequency": {
+                        "type": "integer",
+                        "description": "How frequently the BOS discovery agent syncs new components from HSM. (in seconds)"
+                    },
+                    "logging_level": {
+                        "type": "string",
+                        "description": "The logging level for all BOS services"
+                    },
+                    "max_power_on_wait_time": {
+                        "type": "integer",
+                        "description": "How long BOS will wait for a node to power on before rebooting again (in seconds)"
+                    },
+                    "max_power_off_wait_time": {
+                        "type": "integer",
+                        "description": "How long BOS will wait for a node to power off before forcefully powering off (in seconds)"
+                    },
+                    "polling_frequency": {
+                        "type": "integer",
+                        "description": "How frequently the BOS operators check component state for needed actions. (in seconds)"
+                    }
+                },
+                "additionalProperties": true
+            }
+        },
+        "requestBodies": {
+            "V2sessionCreateRequest": {
+                "description": "The information to create a session",
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "A Session Creation object\n",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the session. A uuid name is generated if a name is not provided.",
+                                    "example": "session-20190728032600",
+                                    "minLength": 1,
+                                    "maxLength": 45,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                                },
+                                "operation": {
+                                    "type": "string",
+                                    "enum": [
+                                        "boot",
+                                        "reboot",
+                                        "shutdown"
+                                    ],
+                                    "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                                },
+                                "template_name": {
+                                    "type": "string",
+                                    "description": "The name of the Session Template",
+                                    "example": "my-session-template",
+                                    "format": "string"
+                                },
+                                "limit": {
+                                    "type": "string",
+                                    "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                },
+                                "stage": {
+                                    "type": "boolean",
+                                    "description": "Set to force nodes to reboot even if they are already in the desired state.\n",
+                                    "default": false
+                                }
+                            },
+                            "required": [
+                                "operation",
+                                "template_name"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "V2componentUpdateRequest": {
+                "description": "The state for a single component",
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "The current and desired artifacts state for a component.\n",
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "description": "The component's id. e.g. xname for hardware components"
+                                },
+                                "actual_state": {
+                                    "description": "The desired boot artifacts and configuration for a component\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "boot_artifacts": {
+                                            "description": "A collection of boot artifacts.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "kernel": {
+                                                    "type": "string",
+                                                    "description": "An md5sum hash of the kernel ID"
+                                                },
+                                                "kernel_parameters": {
+                                                    "type": "string",
+                                                    "description": "Kernel parameters"
+                                                },
+                                                "initrd": {
+                                                    "type": "string",
+                                                    "description": "Initrd ID"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "bss_token": {
+                                            "type": "string",
+                                            "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                        },
+                                        "last_updated": {
+                                            "type": "string",
+                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                            "example": "2019-07-28T03:26:00Z",
+                                            "format": "date-time",
+                                            "readOnly": true
+                                        }
+                                    }
+                                },
+                                "desired_state": {
+                                    "description": "The desired boot artifacts and configuration for a component\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "boot_artifacts": {
+                                            "description": "A collection of boot artifacts.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "kernel": {
+                                                    "type": "string",
+                                                    "description": "An md5sum hash of the kernel ID"
+                                                },
+                                                "kernel_parameters": {
+                                                    "type": "string",
+                                                    "description": "Kernel parameters"
+                                                },
+                                                "initrd": {
+                                                    "type": "string",
+                                                    "description": "Initrd ID"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "configuration": {
+                                            "type": "string",
+                                            "description": "A CFS configuration ID."
+                                        },
+                                        "bss_token": {
+                                            "type": "string",
+                                            "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                        },
+                                        "last_updated": {
+                                            "type": "string",
+                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                            "example": "2019-07-28T03:26:00Z",
+                                            "format": "date-time",
+                                            "readOnly": true
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "staged_state": {
+                                    "description": "The desired boot artifacts and configuration for a component\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "boot_artifacts": {
+                                            "description": "A collection of boot artifacts.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "kernel": {
+                                                    "type": "string",
+                                                    "description": "An md5sum hash of the kernel ID"
+                                                },
+                                                "kernel_parameters": {
+                                                    "type": "string",
+                                                    "description": "Kernel parameters"
+                                                },
+                                                "initrd": {
+                                                    "type": "string",
+                                                    "description": "Initrd ID"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "configuration": {
+                                            "type": "string",
+                                            "description": "A CFS configuration ID."
+                                        },
+                                        "session": {
+                                            "type": "string",
+                                            "description": "A session which can be triggered at a later time against this component."
+                                        },
+                                        "last_updated": {
+                                            "type": "string",
+                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                            "example": "2019-07-28T03:26:00Z",
+                                            "format": "date-time",
+                                            "readOnly": true
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "last_action": {
+                                    "description": "Information on the most recent action taken against the node.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "last_updated": {
+                                            "type": "string",
+                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                            "example": "2019-07-28T03:26:00Z",
+                                            "format": "date-time",
+                                            "readOnly": true
+                                        },
+                                        "action": {
+                                            "type": "string",
+                                            "description": "A description of the most recent operator/action to impact the component."
+                                        },
+                                        "num_attempts": {
+                                            "type": "integer",
+                                            "description": "How many attempts have been made for this action."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "status": {
+                                    "description": "Status information for the component",
+                                    "type": "object",
+                                    "properties": {
+                                        "phase": {
+                                            "type": "string",
+                                            "description": "The current phase of the component in the boot process."
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "description": "The current status of the component.  More detailed than phase.",
+                                            "readOnly": true
+                                        },
+                                        "status_override": {
+                                            "type": "string",
+                                            "description": "If set, this will override the status value."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "A flag indicating if actions should be taken for this component."
+                                },
+                                "error": {
+                                    "type": "string",
+                                    "description": "A description of the most recent error to impact the component."
+                                },
+                                "session": {
+                                    "type": "string",
+                                    "description": "The session responsible for the component's current state"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "V2componentsPutRequest": {
+                "description": "The state for an array of components",
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "An array of component states.",
+                            "type": "array",
+                            "items": {
+                                "description": "The current and desired artifacts state for a component.\n",
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The component's id. e.g. xname for hardware components"
+                                    },
+                                    "actual_state": {
+                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "boot_artifacts": {
+                                                "description": "A collection of boot artifacts.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "kernel": {
+                                                        "type": "string",
+                                                        "description": "An md5sum hash of the kernel ID"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "Kernel parameters"
+                                                    },
+                                                    "initrd": {
+                                                        "type": "string",
+                                                        "description": "Initrd ID"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "bss_token": {
+                                                "type": "string",
+                                                "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                            },
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            }
+                                        }
+                                    },
+                                    "desired_state": {
+                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "boot_artifacts": {
+                                                "description": "A collection of boot artifacts.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "kernel": {
+                                                        "type": "string",
+                                                        "description": "An md5sum hash of the kernel ID"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "Kernel parameters"
+                                                    },
+                                                    "initrd": {
+                                                        "type": "string",
+                                                        "description": "Initrd ID"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "configuration": {
+                                                "type": "string",
+                                                "description": "A CFS configuration ID."
+                                            },
+                                            "bss_token": {
+                                                "type": "string",
+                                                "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                            },
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "staged_state": {
+                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "boot_artifacts": {
+                                                "description": "A collection of boot artifacts.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "kernel": {
+                                                        "type": "string",
+                                                        "description": "An md5sum hash of the kernel ID"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "Kernel parameters"
+                                                    },
+                                                    "initrd": {
+                                                        "type": "string",
+                                                        "description": "Initrd ID"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "configuration": {
+                                                "type": "string",
+                                                "description": "A CFS configuration ID."
+                                            },
+                                            "session": {
+                                                "type": "string",
+                                                "description": "A session which can be triggered at a later time against this component."
+                                            },
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "last_action": {
+                                        "description": "Information on the most recent action taken against the node.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            },
+                                            "action": {
+                                                "type": "string",
+                                                "description": "A description of the most recent operator/action to impact the component."
+                                            },
+                                            "num_attempts": {
+                                                "type": "integer",
+                                                "description": "How many attempts have been made for this action."
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "status": {
+                                        "description": "Status information for the component",
+                                        "type": "object",
+                                        "properties": {
+                                            "phase": {
+                                                "type": "string",
+                                                "description": "The current phase of the component in the boot process."
+                                            },
+                                            "status": {
+                                                "type": "string",
+                                                "description": "The current status of the component.  More detailed than phase.",
+                                                "readOnly": true
+                                            },
+                                            "status_override": {
+                                                "type": "string",
+                                                "description": "If set, this will override the status value."
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "enabled": {
+                                        "type": "boolean",
+                                        "description": "A flag indicating if actions should be taken for this component."
+                                    },
+                                    "error": {
+                                        "type": "string",
+                                        "description": "A description of the most recent error to impact the component."
+                                    },
+                                    "session": {
+                                        "type": "string",
+                                        "description": "The session responsible for the component's current state"
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                }
+            },
+            "V2componentsUpdateRequest": {
+                "description": "The state for an array of components",
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "description": "Information for patching multiple components.",
+                                    "type": "object",
+                                    "properties": {
+                                        "patch": {
+                                            "description": "The current and desired artifacts state for a component.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string",
+                                                    "description": "The component's id. e.g. xname for hardware components"
+                                                },
+                                                "actual_state": {
+                                                    "description": "The desired boot artifacts and configuration for a component\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "boot_artifacts": {
+                                                            "description": "A collection of boot artifacts.\n",
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "kernel": {
+                                                                    "type": "string",
+                                                                    "description": "An md5sum hash of the kernel ID"
+                                                                },
+                                                                "kernel_parameters": {
+                                                                    "type": "string",
+                                                                    "description": "Kernel parameters"
+                                                                },
+                                                                "initrd": {
+                                                                    "type": "string",
+                                                                    "description": "Initrd ID"
+                                                                }
+                                                            },
+                                                            "additionalProperties": false
+                                                        },
+                                                        "bss_token": {
+                                                            "type": "string",
+                                                            "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                        },
+                                                        "last_updated": {
+                                                            "type": "string",
+                                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                            "example": "2019-07-28T03:26:00Z",
+                                                            "format": "date-time",
+                                                            "readOnly": true
+                                                        }
+                                                    }
+                                                },
+                                                "desired_state": {
+                                                    "description": "The desired boot artifacts and configuration for a component\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "boot_artifacts": {
+                                                            "description": "A collection of boot artifacts.\n",
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "kernel": {
+                                                                    "type": "string",
+                                                                    "description": "An md5sum hash of the kernel ID"
+                                                                },
+                                                                "kernel_parameters": {
+                                                                    "type": "string",
+                                                                    "description": "Kernel parameters"
+                                                                },
+                                                                "initrd": {
+                                                                    "type": "string",
+                                                                    "description": "Initrd ID"
+                                                                }
+                                                            },
+                                                            "additionalProperties": false
+                                                        },
+                                                        "configuration": {
+                                                            "type": "string",
+                                                            "description": "A CFS configuration ID."
+                                                        },
+                                                        "bss_token": {
+                                                            "type": "string",
+                                                            "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                        },
+                                                        "last_updated": {
+                                                            "type": "string",
+                                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                            "example": "2019-07-28T03:26:00Z",
+                                                            "format": "date-time",
+                                                            "readOnly": true
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "staged_state": {
+                                                    "description": "The desired boot artifacts and configuration for a component\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "boot_artifacts": {
+                                                            "description": "A collection of boot artifacts.\n",
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "kernel": {
+                                                                    "type": "string",
+                                                                    "description": "An md5sum hash of the kernel ID"
+                                                                },
+                                                                "kernel_parameters": {
+                                                                    "type": "string",
+                                                                    "description": "Kernel parameters"
+                                                                },
+                                                                "initrd": {
+                                                                    "type": "string",
+                                                                    "description": "Initrd ID"
+                                                                }
+                                                            },
+                                                            "additionalProperties": false
+                                                        },
+                                                        "configuration": {
+                                                            "type": "string",
+                                                            "description": "A CFS configuration ID."
+                                                        },
+                                                        "session": {
+                                                            "type": "string",
+                                                            "description": "A session which can be triggered at a later time against this component."
+                                                        },
+                                                        "last_updated": {
+                                                            "type": "string",
+                                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                            "example": "2019-07-28T03:26:00Z",
+                                                            "format": "date-time",
+                                                            "readOnly": true
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "last_action": {
+                                                    "description": "Information on the most recent action taken against the node.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "last_updated": {
+                                                            "type": "string",
+                                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                            "example": "2019-07-28T03:26:00Z",
+                                                            "format": "date-time",
+                                                            "readOnly": true
+                                                        },
+                                                        "action": {
+                                                            "type": "string",
+                                                            "description": "A description of the most recent operator/action to impact the component."
+                                                        },
+                                                        "num_attempts": {
+                                                            "type": "integer",
+                                                            "description": "How many attempts have been made for this action."
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "status": {
+                                                    "description": "Status information for the component",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "phase": {
+                                                            "type": "string",
+                                                            "description": "The current phase of the component in the boot process."
+                                                        },
+                                                        "status": {
+                                                            "type": "string",
+                                                            "description": "The current status of the component.  More detailed than phase.",
+                                                            "readOnly": true
+                                                        },
+                                                        "status_override": {
+                                                            "type": "string",
+                                                            "description": "If set, this will override the status value."
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "enabled": {
+                                                    "type": "boolean",
+                                                    "description": "A flag indicating if actions should be taken for this component."
+                                                },
+                                                "error": {
+                                                    "type": "string",
+                                                    "description": "A description of the most recent error to impact the component."
+                                                },
+                                                "session": {
+                                                    "type": "string",
+                                                    "description": "The session responsible for the component's current state"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "filters": {
+                                            "description": "Information for patching multiple components.",
+                                            "type": "object",
+                                            "properties": {
+                                                "ids": {
+                                                    "type": "string",
+                                                    "description": "A comma separated list of component ids"
+                                                },
+                                                "session": {
+                                                    "type": "string",
+                                                    "description": "A session name.  All components part of this session will be patched."
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "patch",
+                                        "filters"
+                                    ]
+                                },
+                                {
+                                    "description": "An array of component states.",
+                                    "type": "array",
+                                    "items": {
+                                        "description": "The current and desired artifacts state for a component.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "description": "The component's id. e.g. xname for hardware components"
+                                            },
+                                            "actual_state": {
+                                                "description": "The desired boot artifacts and configuration for a component\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "boot_artifacts": {
+                                                        "description": "A collection of boot artifacts.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kernel": {
+                                                                "type": "string",
+                                                                "description": "An md5sum hash of the kernel ID"
+                                                            },
+                                                            "kernel_parameters": {
+                                                                "type": "string",
+                                                                "description": "Kernel parameters"
+                                                            },
+                                                            "initrd": {
+                                                                "type": "string",
+                                                                "description": "Initrd ID"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "bss_token": {
+                                                        "type": "string",
+                                                        "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                    },
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    }
+                                                }
+                                            },
+                                            "desired_state": {
+                                                "description": "The desired boot artifacts and configuration for a component\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "boot_artifacts": {
+                                                        "description": "A collection of boot artifacts.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kernel": {
+                                                                "type": "string",
+                                                                "description": "An md5sum hash of the kernel ID"
+                                                            },
+                                                            "kernel_parameters": {
+                                                                "type": "string",
+                                                                "description": "Kernel parameters"
+                                                            },
+                                                            "initrd": {
+                                                                "type": "string",
+                                                                "description": "Initrd ID"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "configuration": {
+                                                        "type": "string",
+                                                        "description": "A CFS configuration ID."
+                                                    },
+                                                    "bss_token": {
+                                                        "type": "string",
+                                                        "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                    },
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "staged_state": {
+                                                "description": "The desired boot artifacts and configuration for a component\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "boot_artifacts": {
+                                                        "description": "A collection of boot artifacts.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kernel": {
+                                                                "type": "string",
+                                                                "description": "An md5sum hash of the kernel ID"
+                                                            },
+                                                            "kernel_parameters": {
+                                                                "type": "string",
+                                                                "description": "Kernel parameters"
+                                                            },
+                                                            "initrd": {
+                                                                "type": "string",
+                                                                "description": "Initrd ID"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "configuration": {
+                                                        "type": "string",
+                                                        "description": "A CFS configuration ID."
+                                                    },
+                                                    "session": {
+                                                        "type": "string",
+                                                        "description": "A session which can be triggered at a later time against this component."
+                                                    },
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "last_action": {
+                                                "description": "Information on the most recent action taken against the node.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    },
+                                                    "action": {
+                                                        "type": "string",
+                                                        "description": "A description of the most recent operator/action to impact the component."
+                                                    },
+                                                    "num_attempts": {
+                                                        "type": "integer",
+                                                        "description": "How many attempts have been made for this action."
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "status": {
+                                                "description": "Status information for the component",
+                                                "type": "object",
+                                                "properties": {
+                                                    "phase": {
+                                                        "type": "string",
+                                                        "description": "The current phase of the component in the boot process."
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "description": "The current status of the component.  More detailed than phase.",
+                                                        "readOnly": true
+                                                    },
+                                                    "status_override": {
+                                                        "type": "string",
+                                                        "description": "If set, this will override the status value."
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "enabled": {
+                                                "type": "boolean",
+                                                "description": "A flag indicating if actions should be taken for this component."
+                                            },
+                                            "error": {
+                                                "type": "string",
+                                                "description": "A description of the most recent error to impact the component."
+                                            },
+                                            "session": {
+                                                "type": "string",
+                                                "description": "The session responsible for the component's current state"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "V2optionsUpdateRequest": {
+                "description": "Service-wide options",
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "Options for the boot orchestration service.\n",
+                            "type": "object",
+                            "properties": {
+                                "cleanup_completed_session_ttl": {
+                                    "type": "string",
+                                    "description": "Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior."
+                                },
+                                "component_actual_state_ttl": {
+                                    "type": "string",
+                                    "description": "The maximum amount of time a component's actual state is considered valid (in hours). 0h disables cleanup behavior for newly booted nodes and instructs bos-state-reporter to report once instead of periodically."
+                                },
+                                "disable_components_on_completion": {
+                                    "type": "boolean",
+                                    "description": "Allows for BOS components to be marked as disabled after a session has been completed. If false, BOS will continue to maintain the state of the nodes declaratively, even after a session finishes."
+                                },
+                                "discovery_frequency": {
+                                    "type": "integer",
+                                    "description": "How frequently the BOS discovery agent syncs new components from HSM. (in seconds)"
+                                },
+                                "logging_level": {
+                                    "type": "string",
+                                    "description": "The logging level for all BOS services"
+                                },
+                                "max_power_on_wait_time": {
+                                    "type": "integer",
+                                    "description": "How long BOS will wait for a node to power on before rebooting again (in seconds)"
+                                },
+                                "max_power_off_wait_time": {
+                                    "type": "integer",
+                                    "description": "How long BOS will wait for a node to power off before forcefully powering off (in seconds)"
+                                },
+                                "polling_frequency": {
+                                    "type": "integer",
+                                    "description": "How frequently the BOS operators check component state for needed actions. (in seconds)"
+                                }
+                            },
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "V2sessionUpdateRequest": {
+                "description": "The state for a single session",
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "A Session object\n\n## Link Relationships\n\n* self : The session object\n",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the session.\n"
+                                },
+                                "operation": {
+                                    "type": "string",
+                                    "enum": [
+                                        "boot",
+                                        "reboot",
+                                        "shutdown"
+                                    ],
+                                    "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                                },
+                                "template_name": {
+                                    "type": "string",
+                                    "description": "The name of the Session Template",
+                                    "example": "my-session-template",
+                                    "format": "string"
+                                },
+                                "limit": {
+                                    "type": "string",
+                                    "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                },
+                                "stage": {
+                                    "type": "boolean",
+                                    "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                                },
+                                "components": {
+                                    "type": "string",
+                                    "description": "A comma separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
+                                },
+                                "status": {
+                                    "type": "object",
+                                    "description": "Information on the status of a session.\n",
+                                    "properties": {
+                                        "start_time": {
+                                            "type": "string",
+                                            "description": "When the session was created.\n"
+                                        },
+                                        "end_time": {
+                                            "type": "string",
+                                            "description": "When the session completed.\n"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "pending",
+                                                "running",
+                                                "complete"
+                                            ],
+                                            "description": "The status of a session.\n"
+                                        },
+                                        "error": {
+                                            "type": "string",
+                                            "description": "Error which prevented the session from running\n"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "V2applyStagedRequest": {
+                "description": "A list of xnames that should have their staged session applied.",
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "A list of components that should have their staged session applied.\n",
+                            "type": "object",
+                            "properties": {
+                                "xnames": {
+                                    "description": "The list of component xnames",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
             }
         },
         "responses": {
-            "badRequest": {
-                "description": "Bad Request",
+            "ServiceHealth": {
+                "description": "Service Health information",
                 "content": {
-                    "application/problem+json": {
+                    "application/json": {
                         "schema": {
-                            "description": "An error response for RFC 7807 problem details.",
+                            "description": "Service health status",
                             "type": "object",
                             "properties": {
-                                "type": {
-                                    "description": "Relative URI reference to the type of problem which includes human readable documentation.",
-                                    "type": "string",
-                                    "format": "uri",
-                                    "default": "about:blank"
-                                },
-                                "title": {
-                                    "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                "etcdStatus": {
                                     "type": "string"
                                 },
-                                "status": {
-                                    "description": "HTTP status code",
-                                    "type": "integer",
-                                    "example": 400
-                                },
-                                "instance": {
-                                    "description": "A relative URI reference that identifies the specific occurrence of the problem",
-                                    "format": "uri",
-                                    "type": "string"
-                                },
-                                "detail": {
-                                    "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                "apiStatus": {
                                     "type": "string"
                                 }
                             },
@@ -1015,37 +3526,38 @@
                     }
                 }
             },
-            "serviceUnavailable": {
-                "description": "Service Unavailable",
+            "Version": {
+                "description": "Get version details\nThe versioning system uses [semver](https://semver.org/).\n## Link Relationships\n* self : Link to itself\n* versions : Link back to the versions resource\n",
                 "content": {
-                    "application/problem+json": {
+                    "application/json": {
                         "schema": {
-                            "description": "An error response for RFC 7807 problem details.",
+                            "description": "Version data",
                             "type": "object",
                             "properties": {
-                                "type": {
-                                    "description": "Relative URI reference to the type of problem which includes human readable documentation.",
-                                    "type": "string",
-                                    "format": "uri",
-                                    "default": "about:blank"
+                                "major": {
+                                    "type": "integer"
                                 },
-                                "title": {
-                                    "description": "Short, human-readable summary of the problem, should not change by occurrence.",
-                                    "type": "string"
+                                "minor": {
+                                    "type": "integer"
                                 },
-                                "status": {
-                                    "description": "HTTP status code",
-                                    "type": "integer",
-                                    "example": 400
+                                "patch": {
+                                    "type": "integer"
                                 },
-                                "instance": {
-                                    "description": "A relative URI reference that identifies the specific occurrence of the problem",
-                                    "format": "uri",
-                                    "type": "string"
-                                },
-                                "detail": {
-                                    "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
-                                    "type": "string"
+                                "links": {
+                                    "type": "array",
+                                    "items": {
+                                        "description": "Link to other resources",
+                                        "type": "object",
+                                        "properties": {
+                                            "rel": {
+                                                "type": "string"
+                                            },
+                                            "href": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
                                 }
                             },
                             "additionalProperties": false
@@ -1053,7 +3565,10 @@
                     }
                 }
             },
-            "v1SessionDetails": {
+            "ResourceDeleted": {
+                "description": "The resource was deleted."
+            },
+            "V1SessionDetails": {
                 "description": "Session details",
                 "content": {
                     "application/json": {
@@ -1068,13 +3583,26 @@
                                 },
                                 "templateUuid": {
                                     "type": "string",
+                                    "description": "DEPRECATED - use templateName",
+                                    "example": "my-session-template",
+                                    "format": "string"
+                                },
+                                "templateName": {
+                                    "type": "string",
                                     "description": "The name of the Session Template",
                                     "example": "my-session-template",
                                     "format": "string"
                                 },
+                                "job": {
+                                    "type": "string",
+                                    "maxLength": 64,
+                                    "readOnly": true,
+                                    "description": "The identity of the k8s job that is created to handle the session.\n",
+                                    "example": "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
+                                },
                                 "limit": {
                                     "type": "string",
-                                    "description": "A comma seperated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                    "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
                                 },
                                 "links": {
                                     "type": "array",
@@ -1095,15 +3623,14 @@
                                 }
                             },
                             "required": [
-                                "operation",
-                                "templateUuid"
+                                "operation"
                             ],
                             "additionalProperties": false
                         }
                     }
                 }
             },
-            "v1SessionStatus": {
+            "V1SessionStatus": {
                 "description": "A list of Boot Set Statuses and metadata",
                 "content": {
                     "application/json": {
@@ -1176,7 +3703,7 @@
                     }
                 }
             },
-            "v1SessionTemplateDetails": {
+            "V1SessionTemplateDetails": {
                 "description": "Session template details",
                 "content": {
                     "application/json": {
@@ -1186,11 +3713,7 @@
                             "properties": {
                                 "templateUrl": {
                                     "type": "string",
-                                    "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters (excluding templateBody).\n"
-                                },
-                                "templateBody": {
-                                    "type": "string",
-                                    "description": "Do not use. To be removed.\n"
+                                    "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
                                 },
                                 "name": {
                                     "type": "string",
@@ -1354,8 +3877,999 @@
                     }
                 }
             },
-            "sessionTemplateNotFound": {
-                "description": "The session template was not found",
+            "V2SessionTemplateDetails": {
+                "description": "Session template details",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which applies the data to\ngroup of components.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
+                                    "example": "cle-1.0.0",
+                                    "minLength": 1,
+                                    "maxLength": 45,
+                                    "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
+                                    "readOnly": true
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "description": "An optional description for the session template.\n"
+                                },
+                                "enable_cfs": {
+                                    "type": "boolean",
+                                    "description": "Whether to enable the Configuration Framework Service (CFS).\nChoices: true/false\n",
+                                    "default": true
+                                },
+                                "cfs": {
+                                    "type": "object",
+                                    "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                    "properties": {
+                                        "configuration": {
+                                            "type": "string",
+                                            "description": "The name of configuration to be applied.\n"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "boot_sets": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "description": "A boot set is a collection of nodes defined by an explicit list, their functional\nrole, and their logical groupings. This collection of nodes is associated with one\nset of boot artifacts and optional additional records for configuration and root\nfilesystem provisioning.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The Boot Set name.\n"
+                                            },
+                                            "path": {
+                                                "type": "string",
+                                                "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
+                                            },
+                                            "cfs": {
+                                                "type": "object",
+                                                "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                                "properties": {
+                                                    "configuration": {
+                                                        "type": "string",
+                                                        "description": "The name of configuration to be applied.\n"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "type": {
+                                                "type": "string",
+                                                "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
+                                            },
+                                            "etag": {
+                                                "type": "string",
+                                                "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
+                                            },
+                                            "kernel_parameters": {
+                                                "type": "string",
+                                                "description": "The kernel parameters to use to boot the nodes.\n"
+                                            },
+                                            "node_list": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "minItems": 1,
+                                                "description": "The node list. This is an explicit mapping against hardware xnames.\n"
+                                            },
+                                            "node_roles_groups": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "minItems": 1,
+                                                "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
+                                            },
+                                            "node_groups": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "minItems": 1,
+                                                "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
+                                            },
+                                            "rootfs_provider": {
+                                                "type": "string",
+                                                "description": "The root file system provider.\n"
+                                            },
+                                            "rootfs_provider_passthrough": {
+                                                "type": "string",
+                                                "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
+                                            }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": [
+                                            "path",
+                                            "type"
+                                        ]
+                                    }
+                                },
+                                "links": {
+                                    "type": "array",
+                                    "readOnly": true,
+                                    "items": {
+                                        "description": "Link to other resources",
+                                        "type": "object",
+                                        "properties": {
+                                            "rel": {
+                                                "type": "string"
+                                            },
+                                            "href": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                }
+                            },
+                            "required": [],
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "V2SessionTemplateDetailsArray": {
+                "description": "Session template details",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "An array of session templates.",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which applies the data to\ngroup of components.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
+                                        "example": "cle-1.0.0",
+                                        "minLength": 1,
+                                        "maxLength": 45,
+                                        "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
+                                        "readOnly": true
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "description": "An optional description for the session template.\n"
+                                    },
+                                    "enable_cfs": {
+                                        "type": "boolean",
+                                        "description": "Whether to enable the Configuration Framework Service (CFS).\nChoices: true/false\n",
+                                        "default": true
+                                    },
+                                    "cfs": {
+                                        "type": "object",
+                                        "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                        "properties": {
+                                            "configuration": {
+                                                "type": "string",
+                                                "description": "The name of configuration to be applied.\n"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "boot_sets": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                            "description": "A boot set is a collection of nodes defined by an explicit list, their functional\nrole, and their logical groupings. This collection of nodes is associated with one\nset of boot artifacts and optional additional records for configuration and root\nfilesystem provisioning.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "The Boot Set name.\n"
+                                                },
+                                                "path": {
+                                                    "type": "string",
+                                                    "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
+                                                },
+                                                "cfs": {
+                                                    "type": "object",
+                                                    "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                                    "properties": {
+                                                        "configuration": {
+                                                            "type": "string",
+                                                            "description": "The name of configuration to be applied.\n"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "type": {
+                                                    "type": "string",
+                                                    "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
+                                                },
+                                                "etag": {
+                                                    "type": "string",
+                                                    "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
+                                                },
+                                                "kernel_parameters": {
+                                                    "type": "string",
+                                                    "description": "The kernel parameters to use to boot the nodes.\n"
+                                                },
+                                                "node_list": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "minItems": 1,
+                                                    "description": "The node list. This is an explicit mapping against hardware xnames.\n"
+                                                },
+                                                "node_roles_groups": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "minItems": 1,
+                                                    "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
+                                                },
+                                                "node_groups": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "minItems": 1,
+                                                    "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
+                                                },
+                                                "rootfs_provider": {
+                                                    "type": "string",
+                                                    "description": "The root file system provider.\n"
+                                                },
+                                                "rootfs_provider_passthrough": {
+                                                    "type": "string",
+                                                    "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
+                                                }
+                                            },
+                                            "additionalProperties": false,
+                                            "required": [
+                                                "path",
+                                                "type"
+                                            ]
+                                        }
+                                    },
+                                    "links": {
+                                        "type": "array",
+                                        "readOnly": true,
+                                        "items": {
+                                            "description": "Link to other resources",
+                                            "type": "object",
+                                            "properties": {
+                                                "rel": {
+                                                    "type": "string"
+                                                },
+                                                "href": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                },
+                                "required": [],
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                }
+            },
+            "V2SessionTemplateValidation": {
+                "description": "Session template validity details",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "Message describing errors or incompleteness in a Session Template.\n",
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "V2SessionDetails": {
+                "description": "Session details",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "A Session object\n\n## Link Relationships\n\n* self : The session object\n",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the session.\n"
+                                },
+                                "operation": {
+                                    "type": "string",
+                                    "enum": [
+                                        "boot",
+                                        "reboot",
+                                        "shutdown"
+                                    ],
+                                    "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                                },
+                                "template_name": {
+                                    "type": "string",
+                                    "description": "The name of the Session Template",
+                                    "example": "my-session-template",
+                                    "format": "string"
+                                },
+                                "limit": {
+                                    "type": "string",
+                                    "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                },
+                                "stage": {
+                                    "type": "boolean",
+                                    "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                                },
+                                "components": {
+                                    "type": "string",
+                                    "description": "A comma separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
+                                },
+                                "status": {
+                                    "type": "object",
+                                    "description": "Information on the status of a session.\n",
+                                    "properties": {
+                                        "start_time": {
+                                            "type": "string",
+                                            "description": "When the session was created.\n"
+                                        },
+                                        "end_time": {
+                                            "type": "string",
+                                            "description": "When the session completed.\n"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "pending",
+                                                "running",
+                                                "complete"
+                                            ],
+                                            "description": "The status of a session.\n"
+                                        },
+                                        "error": {
+                                            "type": "string",
+                                            "description": "Error which prevented the session from running\n"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "V2SessionDetailsArray": {
+                "description": "Session details",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "An array of sessions.",
+                            "type": "array",
+                            "items": {
+                                "description": "A Session object\n\n## Link Relationships\n\n* self : The session object\n",
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Name of the session.\n"
+                                    },
+                                    "operation": {
+                                        "type": "string",
+                                        "enum": [
+                                            "boot",
+                                            "reboot",
+                                            "shutdown"
+                                        ],
+                                        "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                                    },
+                                    "template_name": {
+                                        "type": "string",
+                                        "description": "The name of the Session Template",
+                                        "example": "my-session-template",
+                                        "format": "string"
+                                    },
+                                    "limit": {
+                                        "type": "string",
+                                        "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                    },
+                                    "stage": {
+                                        "type": "boolean",
+                                        "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                                    },
+                                    "components": {
+                                        "type": "string",
+                                        "description": "A comma separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
+                                    },
+                                    "status": {
+                                        "type": "object",
+                                        "description": "Information on the status of a session.\n",
+                                        "properties": {
+                                            "start_time": {
+                                                "type": "string",
+                                                "description": "When the session was created.\n"
+                                            },
+                                            "end_time": {
+                                                "type": "string",
+                                                "description": "When the session completed.\n"
+                                            },
+                                            "status": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "pending",
+                                                    "running",
+                                                    "complete"
+                                                ],
+                                                "description": "The status of a session.\n"
+                                            },
+                                            "error": {
+                                                "type": "string",
+                                                "description": "Error which prevented the session from running\n"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                }
+            },
+            "V2SessionExtendedStatus": {
+                "description": "Session status details",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "description": "Detailed information on the status of a session.\n",
+                            "properties": {
+                                "status": {
+                                    "type": "string",
+                                    "enum": [
+                                        "pending",
+                                        "running",
+                                        "complete"
+                                    ],
+                                    "description": "The status of a session.\n"
+                                },
+                                "managed_components_count": {
+                                    "type": "integer",
+                                    "description": "The count of components currently managed by this session\n"
+                                },
+                                "phases": {
+                                    "type": "object",
+                                    "description": "Detailed information on the phases of a session.\n",
+                                    "properties": {
+                                        "percent_complete": {
+                                            "type": "float",
+                                            "description": "The percent of components currently in a completed/stable state\n"
+                                        },
+                                        "percent_powering_on": {
+                                            "type": "float",
+                                            "description": "The percent of components currently in the powering-on phase\n"
+                                        },
+                                        "percent_powering_off": {
+                                            "type": "float",
+                                            "description": "The percent of components currently in the powering-off phase\n"
+                                        },
+                                        "percent_configuring": {
+                                            "type": "float",
+                                            "description": "The percent of components currently in the configuring phase\n"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "percent_successful": {
+                                    "type": "float",
+                                    "description": "The percent of components currently in a successful state\n"
+                                },
+                                "percent_failed": {
+                                    "type": "float",
+                                    "description": "The percent of components currently in a failed state\n"
+                                },
+                                "percent_staged": {
+                                    "type": "float",
+                                    "description": "The percent of components currently still staged for this session\n"
+                                },
+                                "error_summary": {
+                                    "type": "object",
+                                    "description": "A summary of the errors currently listed by all components\n"
+                                },
+                                "timing": {
+                                    "type": "object",
+                                    "description": "Detailed information on the timing of a session.\n",
+                                    "properties": {
+                                        "start_time": {
+                                            "type": "string",
+                                            "description": "When the session was created.\n"
+                                        },
+                                        "end_time": {
+                                            "type": "string",
+                                            "description": "When the session completed.\n"
+                                        },
+                                        "duration": {
+                                            "type": "string",
+                                            "description": "The current duration of the on-going session or final duration of the completed session.\n"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "V2componentDetails": {
+                "description": "A single component state",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "The current and desired artifacts state for a component.\n",
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "description": "The component's id. e.g. xname for hardware components"
+                                },
+                                "actual_state": {
+                                    "description": "The desired boot artifacts and configuration for a component\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "boot_artifacts": {
+                                            "description": "A collection of boot artifacts.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "kernel": {
+                                                    "type": "string",
+                                                    "description": "An md5sum hash of the kernel ID"
+                                                },
+                                                "kernel_parameters": {
+                                                    "type": "string",
+                                                    "description": "Kernel parameters"
+                                                },
+                                                "initrd": {
+                                                    "type": "string",
+                                                    "description": "Initrd ID"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "bss_token": {
+                                            "type": "string",
+                                            "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                        },
+                                        "last_updated": {
+                                            "type": "string",
+                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                            "example": "2019-07-28T03:26:00Z",
+                                            "format": "date-time",
+                                            "readOnly": true
+                                        }
+                                    }
+                                },
+                                "desired_state": {
+                                    "description": "The desired boot artifacts and configuration for a component\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "boot_artifacts": {
+                                            "description": "A collection of boot artifacts.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "kernel": {
+                                                    "type": "string",
+                                                    "description": "An md5sum hash of the kernel ID"
+                                                },
+                                                "kernel_parameters": {
+                                                    "type": "string",
+                                                    "description": "Kernel parameters"
+                                                },
+                                                "initrd": {
+                                                    "type": "string",
+                                                    "description": "Initrd ID"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "configuration": {
+                                            "type": "string",
+                                            "description": "A CFS configuration ID."
+                                        },
+                                        "bss_token": {
+                                            "type": "string",
+                                            "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                        },
+                                        "last_updated": {
+                                            "type": "string",
+                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                            "example": "2019-07-28T03:26:00Z",
+                                            "format": "date-time",
+                                            "readOnly": true
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "staged_state": {
+                                    "description": "The desired boot artifacts and configuration for a component\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "boot_artifacts": {
+                                            "description": "A collection of boot artifacts.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "kernel": {
+                                                    "type": "string",
+                                                    "description": "An md5sum hash of the kernel ID"
+                                                },
+                                                "kernel_parameters": {
+                                                    "type": "string",
+                                                    "description": "Kernel parameters"
+                                                },
+                                                "initrd": {
+                                                    "type": "string",
+                                                    "description": "Initrd ID"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "configuration": {
+                                            "type": "string",
+                                            "description": "A CFS configuration ID."
+                                        },
+                                        "session": {
+                                            "type": "string",
+                                            "description": "A session which can be triggered at a later time against this component."
+                                        },
+                                        "last_updated": {
+                                            "type": "string",
+                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                            "example": "2019-07-28T03:26:00Z",
+                                            "format": "date-time",
+                                            "readOnly": true
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "last_action": {
+                                    "description": "Information on the most recent action taken against the node.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "last_updated": {
+                                            "type": "string",
+                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                            "example": "2019-07-28T03:26:00Z",
+                                            "format": "date-time",
+                                            "readOnly": true
+                                        },
+                                        "action": {
+                                            "type": "string",
+                                            "description": "A description of the most recent operator/action to impact the component."
+                                        },
+                                        "num_attempts": {
+                                            "type": "integer",
+                                            "description": "How many attempts have been made for this action."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "status": {
+                                    "description": "Status information for the component",
+                                    "type": "object",
+                                    "properties": {
+                                        "phase": {
+                                            "type": "string",
+                                            "description": "The current phase of the component in the boot process."
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "description": "The current status of the component.  More detailed than phase.",
+                                            "readOnly": true
+                                        },
+                                        "status_override": {
+                                            "type": "string",
+                                            "description": "If set, this will override the status value."
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "A flag indicating if actions should be taken for this component."
+                                },
+                                "error": {
+                                    "type": "string",
+                                    "description": "A description of the most recent error to impact the component."
+                                },
+                                "session": {
+                                    "type": "string",
+                                    "description": "The session responsible for the component's current state"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "V2componentDetailsArray": {
+                "description": "A collection of component states",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "An array of component states.",
+                            "type": "array",
+                            "items": {
+                                "description": "The current and desired artifacts state for a component.\n",
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The component's id. e.g. xname for hardware components"
+                                    },
+                                    "actual_state": {
+                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "boot_artifacts": {
+                                                "description": "A collection of boot artifacts.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "kernel": {
+                                                        "type": "string",
+                                                        "description": "An md5sum hash of the kernel ID"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "Kernel parameters"
+                                                    },
+                                                    "initrd": {
+                                                        "type": "string",
+                                                        "description": "Initrd ID"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "bss_token": {
+                                                "type": "string",
+                                                "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                            },
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            }
+                                        }
+                                    },
+                                    "desired_state": {
+                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "boot_artifacts": {
+                                                "description": "A collection of boot artifacts.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "kernel": {
+                                                        "type": "string",
+                                                        "description": "An md5sum hash of the kernel ID"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "Kernel parameters"
+                                                    },
+                                                    "initrd": {
+                                                        "type": "string",
+                                                        "description": "Initrd ID"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "configuration": {
+                                                "type": "string",
+                                                "description": "A CFS configuration ID."
+                                            },
+                                            "bss_token": {
+                                                "type": "string",
+                                                "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                            },
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "staged_state": {
+                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "boot_artifacts": {
+                                                "description": "A collection of boot artifacts.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "kernel": {
+                                                        "type": "string",
+                                                        "description": "An md5sum hash of the kernel ID"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "Kernel parameters"
+                                                    },
+                                                    "initrd": {
+                                                        "type": "string",
+                                                        "description": "Initrd ID"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "configuration": {
+                                                "type": "string",
+                                                "description": "A CFS configuration ID."
+                                            },
+                                            "session": {
+                                                "type": "string",
+                                                "description": "A session which can be triggered at a later time against this component."
+                                            },
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "last_action": {
+                                        "description": "Information on the most recent action taken against the node.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            },
+                                            "action": {
+                                                "type": "string",
+                                                "description": "A description of the most recent operator/action to impact the component."
+                                            },
+                                            "num_attempts": {
+                                                "type": "integer",
+                                                "description": "How many attempts have been made for this action."
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "status": {
+                                        "description": "Status information for the component",
+                                        "type": "object",
+                                        "properties": {
+                                            "phase": {
+                                                "type": "string",
+                                                "description": "The current phase of the component in the boot process."
+                                            },
+                                            "status": {
+                                                "type": "string",
+                                                "description": "The current status of the component.  More detailed than phase.",
+                                                "readOnly": true
+                                            },
+                                            "status_override": {
+                                                "type": "string",
+                                                "description": "If set, this will override the status value."
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "enabled": {
+                                        "type": "boolean",
+                                        "description": "A flag indicating if actions should be taken for this component."
+                                    },
+                                    "error": {
+                                        "type": "string",
+                                        "description": "A description of the most recent error to impact the component."
+                                    },
+                                    "session": {
+                                        "type": "string",
+                                        "description": "The session responsible for the component's current state"
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                }
+            },
+            "V2applyStagedResponse": {
+                "description": "A list of xnames that should have their staged session applied.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "A list of components that should have their staged session applied.\n",
+                            "type": "object",
+                            "properties": {
+                                "succeeded": {
+                                    "description": "The list of component xnames",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "failed": {
+                                    "description": "The list of component xnames",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "ignored": {
+                                    "description": "The list of component xnames",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "V2options": {
+                "description": "A collection of service-wide options",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "description": "Options for the boot orchestration service.\n",
+                            "type": "object",
+                            "properties": {
+                                "cleanup_completed_session_ttl": {
+                                    "type": "string",
+                                    "description": "Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior."
+                                },
+                                "component_actual_state_ttl": {
+                                    "type": "string",
+                                    "description": "The maximum amount of time a component's actual state is considered valid (in hours). 0h disables cleanup behavior for newly booted nodes and instructs bos-state-reporter to report once instead of periodically."
+                                },
+                                "disable_components_on_completion": {
+                                    "type": "boolean",
+                                    "description": "Allows for BOS components to be marked as disabled after a session has been completed. If false, BOS will continue to maintain the state of the nodes declaratively, even after a session finishes."
+                                },
+                                "discovery_frequency": {
+                                    "type": "integer",
+                                    "description": "How frequently the BOS discovery agent syncs new components from HSM. (in seconds)"
+                                },
+                                "logging_level": {
+                                    "type": "string",
+                                    "description": "The logging level for all BOS services"
+                                },
+                                "max_power_on_wait_time": {
+                                    "type": "integer",
+                                    "description": "How long BOS will wait for a node to power on before rebooting again (in seconds)"
+                                },
+                                "max_power_off_wait_time": {
+                                    "type": "integer",
+                                    "description": "How long BOS will wait for a node to power off before forcefully powering off (in seconds)"
+                                },
+                                "polling_frequency": {
+                                    "type": "integer",
+                                    "description": "How frequently the BOS operators check component state for needed actions. (in seconds)"
+                                }
+                            },
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "BadRequest": {
+                "description": "Bad Request",
                 "content": {
                     "application/problem+json": {
                         "schema": {
@@ -1392,8 +4906,84 @@
                     }
                 }
             },
-            "sessionNotFound": {
-                "description": "The session was not found",
+            "ResourceNotFound": {
+                "description": "The resource was not found.",
+                "content": {
+                    "application/problem+json": {
+                        "schema": {
+                            "description": "An error response for RFC 7807 problem details.",
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                    "type": "string",
+                                    "format": "uri",
+                                    "default": "about:blank"
+                                },
+                                "title": {
+                                    "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "description": "HTTP status code",
+                                    "type": "integer",
+                                    "example": 400
+                                },
+                                "instance": {
+                                    "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                    "format": "uri",
+                                    "type": "string"
+                                },
+                                "detail": {
+                                    "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "ServiceUnavailable": {
+                "description": "Service Unavailable",
+                "content": {
+                    "application/problem+json": {
+                        "schema": {
+                            "description": "An error response for RFC 7807 problem details.",
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                    "type": "string",
+                                    "format": "uri",
+                                    "default": "about:blank"
+                                },
+                                "title": {
+                                    "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "description": "HTTP status code",
+                                    "type": "integer",
+                                    "example": 400
+                                },
+                                "instance": {
+                                    "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                    "format": "uri",
+                                    "type": "string"
+                                },
+                                "detail": {
+                                    "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            },
+            "InternalError": {
+                "description": "An Internal Server Error occurred handling the request.",
                 "content": {
                     "application/problem+json": {
                         "schema": {
@@ -1440,46 +5030,43 @@
                 "tags": [
                     "version"
                 ],
-                "x-openapi-router-controller": "bos.controllers.base",
+                "x-openapi-router-controller": "bos.server.controllers.base",
                 "responses": {
                     "200": {
-                        "description": "Get versions.\n\nThe versioning system uses [semver](https://semver.org/).\n\n## Link Relationships\n\n* self : The version base, e.g., \"/v1\".\n",
+                        "description": "Get version details\nThe versioning system uses [semver](https://semver.org/).\n## Link Relationships\n* self : Link to itself\n* versions : Link back to the versions resource\n",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "description": "Version data",
-                                        "type": "object",
-                                        "properties": {
-                                            "major": {
-                                                "type": "integer"
-                                            },
-                                            "minor": {
-                                                "type": "integer"
-                                            },
-                                            "patch": {
-                                                "type": "integer"
-                                            },
-                                            "links": {
-                                                "type": "array",
-                                                "items": {
-                                                    "description": "Link to other resources",
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "rel": {
-                                                            "type": "string"
-                                                        },
-                                                        "href": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "additionalProperties": false
-                                                }
-                                            }
+                                    "description": "Version data",
+                                    "type": "object",
+                                    "properties": {
+                                        "major": {
+                                            "type": "integer"
                                         },
-                                        "additionalProperties": false
-                                    }
+                                        "minor": {
+                                            "type": "integer"
+                                        },
+                                        "patch": {
+                                            "type": "integer"
+                                        },
+                                        "links": {
+                                            "type": "array",
+                                            "items": {
+                                                "description": "Link to other resources",
+                                                "type": "object",
+                                                "properties": {
+                                                    "rel": {
+                                                        "type": "string"
+                                                    },
+                                                    "href": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            }
+                                        }
+                                    },
+                                    "additionalProperties": false
                                 }
                             }
                         }
@@ -1493,11 +5080,11 @@
                 "tags": [
                     "version"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.base",
+                "x-openapi-router-controller": "bos.server.controllers.v1.base",
                 "operationId": "v1_get",
                 "responses": {
                     "200": {
-                        "description": "Get version details\n\nThe versioning system uses [semver](https://semver.org/).\n\n## Link Relationships\n\n* self : Link to itself\n* versions : Link back to the versions resource\n",
+                        "description": "Get version details\nThe versioning system uses [semver](https://semver.org/).\n## Link Relationships\n* self : Link to itself\n* versions : Link back to the versions resource\n",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1536,7 +5123,7 @@
                         }
                     },
                     "500": {
-                        "description": "An Internal Server Error occurred handling the request.",
+                        "description": "Bad Request",
                         "content": {
                             "application/problem+json": {
                                 "schema": {
@@ -1582,7 +5169,7 @@
                 "tags": [
                     "healthz"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.healthz",
+                "x-openapi-router-controller": "bos.server.controllers.v1.healthz",
                 "operationId": "v1_get_healthz",
                 "description": "Get bos health details.",
                 "responses": {
@@ -1607,7 +5194,7 @@
                         }
                     },
                     "500": {
-                        "description": "An Internal Server Error occurred handling the request.",
+                        "description": "Bad Request",
                         "content": {
                             "application/problem+json": {
                                 "schema": {
@@ -1691,7 +5278,7 @@
                 "tags": [
                     "sessiontemplate"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.sessiontemplate",
+                "x-openapi-router-controller": "bos.server.controllers.v1.sessiontemplate",
                 "operationId": "create_v1_sessiontemplate",
                 "description": "Create a new session template.",
                 "requestBody": {
@@ -1705,11 +5292,7 @@
                                 "properties": {
                                     "templateUrl": {
                                         "type": "string",
-                                        "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters (excluding templateBody).\n"
-                                    },
-                                    "templateBody": {
-                                        "type": "string",
-                                        "description": "Do not use. To be removed.\n"
+                                        "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
                                     },
                                     "name": {
                                         "type": "string",
@@ -1884,11 +5467,7 @@
                                     "properties": {
                                         "templateUrl": {
                                             "type": "string",
-                                            "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters (excluding templateBody).\n"
-                                        },
-                                        "templateBody": {
-                                            "type": "string",
-                                            "description": "Do not use. To be removed.\n"
+                                            "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
                                         },
                                         "name": {
                                             "type": "string",
@@ -2098,7 +5677,7 @@
                 "tags": [
                     "sessiontemplate"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.sessiontemplate",
+                "x-openapi-router-controller": "bos.server.controllers.v1.sessiontemplate",
                 "operationId": "get_v1_sessiontemplates",
                 "responses": {
                     "200": {
@@ -2113,11 +5692,7 @@
                                         "properties": {
                                             "templateUrl": {
                                                 "type": "string",
-                                                "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters (excluding templateBody).\n"
-                                            },
-                                            "templateBody": {
-                                                "type": "string",
-                                                "description": "Do not use. To be removed.\n"
+                                                "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
                                             },
                                             "name": {
                                                 "type": "string",
@@ -2303,7 +5878,7 @@
                 "tags": [
                     "sessiontemplate"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.sessiontemplate",
+                "x-openapi-router-controller": "bos.server.controllers.v1.sessiontemplate",
                 "operationId": "get_v1_sessiontemplate",
                 "responses": {
                     "200": {
@@ -2316,11 +5891,7 @@
                                     "properties": {
                                         "templateUrl": {
                                             "type": "string",
-                                            "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters (excluding templateBody).\n"
-                                        },
-                                        "templateBody": {
-                                            "type": "string",
-                                            "description": "Do not use. To be removed.\n"
+                                            "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
                                         },
                                         "name": {
                                             "type": "string",
@@ -2485,7 +6056,7 @@
                         }
                     },
                     "404": {
-                        "description": "The session template was not found",
+                        "description": "The resource was not found.",
                         "content": {
                             "application/problem+json": {
                                 "schema": {
@@ -2530,14 +6101,14 @@
                 "tags": [
                     "sessiontemplate"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.sessiontemplate",
+                "x-openapi-router-controller": "bos.server.controllers.v1.sessiontemplate",
                 "operationId": "delete_v1_sessiontemplate",
                 "responses": {
                     "204": {
-                        "description": "The session template was deleted."
+                        "description": "The resource was deleted."
                     },
                     "404": {
-                        "description": "The session template was not found",
+                        "description": "The resource was not found.",
                         "content": {
                             "application/problem+json": {
                                 "schema": {
@@ -2584,7 +6155,7 @@
                 "tags": [
                     "sessiontemplate"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.sessiontemplate",
+                "x-openapi-router-controller": "bos.server.controllers.v1.sessiontemplate",
                 "operationId": "get_v1_sessiontemplatetemplate",
                 "responses": {
                     "200": {
@@ -2597,11 +6168,7 @@
                                     "properties": {
                                         "templateUrl": {
                                             "type": "string",
-                                            "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters (excluding templateBody).\n"
-                                        },
-                                        "templateBody": {
-                                            "type": "string",
-                                            "description": "Do not use. To be removed.\n"
+                                            "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
                                         },
                                         "name": {
                                             "type": "string",
@@ -2775,7 +6342,7 @@
                 "tags": [
                     "session"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.session",
+                "x-openapi-router-controller": "bos.server.controllers.v1.session",
                 "operationId": "create_v1_session",
                 "requestBody": {
                     "description": "A JSON object for creating a Session",
@@ -2793,13 +6360,26 @@
                                     },
                                     "templateUuid": {
                                         "type": "string",
+                                        "description": "DEPRECATED - use templateName",
+                                        "example": "my-session-template",
+                                        "format": "string"
+                                    },
+                                    "templateName": {
+                                        "type": "string",
                                         "description": "The name of the Session Template",
                                         "example": "my-session-template",
                                         "format": "string"
                                     },
+                                    "job": {
+                                        "type": "string",
+                                        "maxLength": 64,
+                                        "readOnly": true,
+                                        "description": "The identity of the k8s job that is created to handle the session.\n",
+                                        "example": "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
+                                    },
                                     "limit": {
                                         "type": "string",
-                                        "description": "A comma seperated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                        "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
                                     },
                                     "links": {
                                         "type": "array",
@@ -2820,8 +6400,7 @@
                                     }
                                 },
                                 "required": [
-                                    "operation",
-                                    "templateUuid"
+                                    "operation"
                                 ],
                                 "additionalProperties": false
                             }
@@ -2844,13 +6423,26 @@
                                         },
                                         "templateUuid": {
                                             "type": "string",
+                                            "description": "DEPRECATED - use templateName",
+                                            "example": "my-session-template",
+                                            "format": "string"
+                                        },
+                                        "templateName": {
+                                            "type": "string",
                                             "description": "The name of the Session Template",
                                             "example": "my-session-template",
                                             "format": "string"
                                         },
+                                        "job": {
+                                            "type": "string",
+                                            "maxLength": 64,
+                                            "readOnly": true,
+                                            "description": "The identity of the k8s job that is created to handle the session.\n",
+                                            "example": "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
+                                        },
                                         "limit": {
                                             "type": "string",
-                                            "description": "A comma seperated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                            "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
                                         },
                                         "links": {
                                             "type": "array",
@@ -2871,8 +6463,7 @@
                                         }
                                     },
                                     "required": [
-                                        "operation",
-                                        "templateUuid"
+                                        "operation"
                                     ],
                                     "additionalProperties": false
                                 }
@@ -2925,7 +6516,7 @@
                 "tags": [
                     "session"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.session",
+                "x-openapi-router-controller": "bos.server.controllers.v1.session",
                 "operationId": "get_v1_sessions",
                 "responses": {
                     "200": {
@@ -2945,13 +6536,26 @@
                                             },
                                             "templateUuid": {
                                                 "type": "string",
+                                                "description": "DEPRECATED - use templateName",
+                                                "example": "my-session-template",
+                                                "format": "string"
+                                            },
+                                            "templateName": {
+                                                "type": "string",
                                                 "description": "The name of the Session Template",
                                                 "example": "my-session-template",
                                                 "format": "string"
                                             },
+                                            "job": {
+                                                "type": "string",
+                                                "maxLength": 64,
+                                                "readOnly": true,
+                                                "description": "The identity of the k8s job that is created to handle the session.\n",
+                                                "example": "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
+                                            },
                                             "limit": {
                                                 "type": "string",
-                                                "description": "A comma seperated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                                "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
                                             },
                                             "links": {
                                                 "type": "array",
@@ -2972,8 +6576,7 @@
                                             }
                                         },
                                         "required": [
-                                            "operation",
-                                            "templateUuid"
+                                            "operation"
                                         ],
                                         "additionalProperties": false
                                     }
@@ -2991,7 +6594,7 @@
                 "tags": [
                     "session"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.session",
+                "x-openapi-router-controller": "bos.server.controllers.v1.session",
                 "operationId": "get_v1_session",
                 "responses": {
                     "200": {
@@ -3009,13 +6612,26 @@
                                         },
                                         "templateUuid": {
                                             "type": "string",
+                                            "description": "DEPRECATED - use templateName",
+                                            "example": "my-session-template",
+                                            "format": "string"
+                                        },
+                                        "templateName": {
+                                            "type": "string",
                                             "description": "The name of the Session Template",
                                             "example": "my-session-template",
                                             "format": "string"
                                         },
+                                        "job": {
+                                            "type": "string",
+                                            "maxLength": 64,
+                                            "readOnly": true,
+                                            "description": "The identity of the k8s job that is created to handle the session.\n",
+                                            "example": "boa-07877de1-09bb-4ca8-a4e5-943b1262dbf0"
+                                        },
                                         "limit": {
                                             "type": "string",
-                                            "description": "A comma seperated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                            "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
                                         },
                                         "links": {
                                             "type": "array",
@@ -3036,8 +6652,7 @@
                                         }
                                     },
                                     "required": [
-                                        "operation",
-                                        "templateUuid"
+                                        "operation"
                                     ],
                                     "additionalProperties": false
                                 }
@@ -3045,7 +6660,7 @@
                         }
                     },
                     "404": {
-                        "description": "The session was not found",
+                        "description": "The resource was not found.",
                         "content": {
                             "application/problem+json": {
                                 "schema": {
@@ -3090,14 +6705,14 @@
                 "tags": [
                     "session"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.session",
+                "x-openapi-router-controller": "bos.server.controllers.v1.session",
                 "operationId": "delete_v1_session",
                 "responses": {
                     "204": {
-                        "description": "The session was deleted."
+                        "description": "The resource was deleted."
                     },
                     "404": {
-                        "description": "The session was not found",
+                        "description": "The resource was not found.",
                         "content": {
                             "application/problem+json": {
                                 "schema": {
@@ -3166,7 +6781,7 @@
                 "tags": [
                     "session"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.status",
+                "x-openapi-router-controller": "bos.server.controllers.v1.status",
                 "operationId": "get_v1_session_status",
                 "responses": {
                     "200": {
@@ -3243,7 +6858,7 @@
                         }
                     },
                     "404": {
-                        "description": "The session was not found",
+                        "description": "The resource was not found.",
                         "content": {
                             "application/problem+json": {
                                 "schema": {
@@ -3288,7 +6903,7 @@
                 "tags": [
                     "session"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.status",
+                "x-openapi-router-controller": "bos.server.controllers.v1.status",
                 "operationId": "create_v1_session_status",
                 "requestBody": {
                     "description": "A JSON object for creating the status for a session",
@@ -3484,7 +7099,7 @@
                 "tags": [
                     "session"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.status",
+                "x-openapi-router-controller": "bos.server.controllers.v1.status",
                 "operationId": "update_v1_session_status",
                 "requestBody": {
                     "description": "A JSON object for updating the status for a session",
@@ -3646,11 +7261,11 @@
                 "tags": [
                     "session"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.status",
+                "x-openapi-router-controller": "bos.server.controllers.v1.status",
                 "operationId": "delete_v1_session_status",
                 "responses": {
                     "204": {
-                        "description": "The status was deleted successfully."
+                        "description": "The resource was deleted."
                     },
                     "400": {
                         "description": "Bad Request",
@@ -3720,7 +7335,7 @@
                 "tags": [
                     "session"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.status",
+                "x-openapi-router-controller": "bos.server.controllers.v1.status",
                 "operationId": "get_v1_session_status_by_bootset",
                 "responses": {
                     "200": {
@@ -3882,7 +7497,7 @@
                         }
                     },
                     "404": {
-                        "description": "The session was not found",
+                        "description": "The resource was not found.",
                         "content": {
                             "application/problem+json": {
                                 "schema": {
@@ -3928,7 +7543,7 @@
                     "session",
                     "status"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.status",
+                "x-openapi-router-controller": "bos.server.controllers.v1.status",
                 "operationId": "create_v1_boot_set_status",
                 "requestBody": {
                     "description": "A JSON object for creating a status for a Boot Set",
@@ -4254,10 +7869,9 @@
                 "summary": "Update the status.",
                 "description": "This will change the status for one or more nodes within\nthe boot set.\n",
                 "tags": [
-                    "session",
-                    "cli_ignore"
+                    "session"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.status",
+                "x-openapi-router-controller": "bos.server.controllers.v1.status",
                 "operationId": "update_v1_session_status_by_bootset",
                 "requestBody": {
                     "description": "A JSON object for updating the status for a session",
@@ -4569,7 +8183,7 @@
                         }
                     },
                     "404": {
-                        "description": "The session was not found",
+                        "description": "The resource was not found.",
                         "content": {
                             "application/problem+json": {
                                 "schema": {
@@ -4614,11 +8228,11 @@
                 "tags": [
                     "session"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.status",
+                "x-openapi-router-controller": "bos.server.controllers.v1.status",
                 "operationId": "delete_v1_boot_set_status",
                 "responses": {
                     "204": {
-                        "description": "The status was deleted successfully."
+                        "description": "The resource was deleted."
                     },
                     "400": {
                         "description": "Bad Request",
@@ -4697,7 +8311,7 @@
                 "tags": [
                     "session"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.status",
+                "x-openapi-router-controller": "bos.server.controllers.v1.status",
                 "operationId": "get_v1_session_status_by_bootset_and_phase",
                 "responses": {
                     "200": {
@@ -4791,7 +8405,7 @@
                         }
                     },
                     "404": {
-                        "description": "The session was not found",
+                        "description": "The resource was not found.",
                         "content": {
                             "application/problem+json": {
                                 "schema": {
@@ -4876,7 +8490,7 @@
                 "tags": [
                     "session"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.status",
+                "x-openapi-router-controller": "bos.server.controllers.v1.status",
                 "operationId": "get_v1_session_status_by_bootset_and_phase_and_category",
                 "responses": {
                     "200": {
@@ -4909,7 +8523,7 @@
                         }
                     },
                     "404": {
-                        "description": "The session was not found",
+                        "description": "The resource was not found.",
                         "content": {
                             "application/problem+json": {
                                 "schema": {
@@ -4955,11 +8569,11 @@
                 "tags": [
                     "version"
                 ],
-                "x-openapi-router-controller": "bos.controllers.v1.base",
+                "x-openapi-router-controller": "bos.server.controllers.v1.base",
                 "operationId": "v1_get_version",
                 "responses": {
                     "200": {
-                        "description": "Get version details\n\nThe versioning system uses [semver](https://semver.org/).\n\n## Link Relationships\n\n* self : Link to itself\n* versions : Link back to the versions resource\n",
+                        "description": "Get version details\nThe versioning system uses [semver](https://semver.org/).\n## Link Relationships\n* self : Link to itself\n* versions : Link back to the versions resource\n",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4998,7 +8612,5643 @@
                         }
                     },
                     "500": {
-                        "description": "An Internal Server Error occurred handling the request.",
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v2": {
+            "get": {
+                "summary": "Get API version",
+                "tags": [
+                    "v2",
+                    "version"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.base",
+                "operationId": "get_v2",
+                "responses": {
+                    "200": {
+                        "description": "Get version details\nThe versioning system uses [semver](https://semver.org/).\n## Link Relationships\n* self : Link to itself\n* versions : Link back to the versions resource\n",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "Version data",
+                                    "type": "object",
+                                    "properties": {
+                                        "major": {
+                                            "type": "integer"
+                                        },
+                                        "minor": {
+                                            "type": "integer"
+                                        },
+                                        "patch": {
+                                            "type": "integer"
+                                        },
+                                        "links": {
+                                            "type": "array",
+                                            "items": {
+                                                "description": "Link to other resources",
+                                                "type": "object",
+                                                "properties": {
+                                                    "rel": {
+                                                        "type": "string"
+                                                    },
+                                                    "href": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            }
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/healthz": {
+            "get": {
+                "summary": "Get service health details",
+                "tags": [
+                    "v2",
+                    "healthz"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.healthz",
+                "operationId": "get_v2_healthz",
+                "description": "Get bos health details.",
+                "responses": {
+                    "200": {
+                        "description": "Service Health information",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "Service health status",
+                                    "type": "object",
+                                    "properties": {
+                                        "etcdStatus": {
+                                            "type": "string"
+                                        },
+                                        "apiStatus": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/sessiontemplates": {
+            "get": {
+                "summary": "List session templates",
+                "description": "List all session templates. Session templates are\nuniquely identified by the name.\n",
+                "tags": [
+                    "v2",
+                    "sessiontemplates"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessiontemplates",
+                "operationId": "get_v2_sessiontemplates",
+                "responses": {
+                    "200": {
+                        "description": "Session template details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An array of session templates.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which applies the data to\ngroup of components.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
+                                                "example": "cle-1.0.0",
+                                                "minLength": 1,
+                                                "maxLength": 45,
+                                                "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
+                                                "readOnly": true
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "An optional description for the session template.\n"
+                                            },
+                                            "enable_cfs": {
+                                                "type": "boolean",
+                                                "description": "Whether to enable the Configuration Framework Service (CFS).\nChoices: true/false\n",
+                                                "default": true
+                                            },
+                                            "cfs": {
+                                                "type": "object",
+                                                "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                                "properties": {
+                                                    "configuration": {
+                                                        "type": "string",
+                                                        "description": "The name of configuration to be applied.\n"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "boot_sets": {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "description": "A boot set is a collection of nodes defined by an explicit list, their functional\nrole, and their logical groupings. This collection of nodes is associated with one\nset of boot artifacts and optional additional records for configuration and root\nfilesystem provisioning.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "description": "The Boot Set name.\n"
+                                                        },
+                                                        "path": {
+                                                            "type": "string",
+                                                            "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
+                                                        },
+                                                        "cfs": {
+                                                            "type": "object",
+                                                            "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                                            "properties": {
+                                                                "configuration": {
+                                                                    "type": "string",
+                                                                    "description": "The name of configuration to be applied.\n"
+                                                                }
+                                                            },
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
+                                                        },
+                                                        "etag": {
+                                                            "type": "string",
+                                                            "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
+                                                        },
+                                                        "kernel_parameters": {
+                                                            "type": "string",
+                                                            "description": "The kernel parameters to use to boot the nodes.\n"
+                                                        },
+                                                        "node_list": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "minItems": 1,
+                                                            "description": "The node list. This is an explicit mapping against hardware xnames.\n"
+                                                        },
+                                                        "node_roles_groups": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "minItems": 1,
+                                                            "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
+                                                        },
+                                                        "node_groups": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "minItems": 1,
+                                                            "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
+                                                        },
+                                                        "rootfs_provider": {
+                                                            "type": "string",
+                                                            "description": "The root file system provider.\n"
+                                                        },
+                                                        "rootfs_provider_passthrough": {
+                                                            "type": "string",
+                                                            "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false,
+                                                    "required": [
+                                                        "path",
+                                                        "type"
+                                                    ]
+                                                }
+                                            },
+                                            "links": {
+                                                "type": "array",
+                                                "readOnly": true,
+                                                "items": {
+                                                    "description": "Link to other resources",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "rel": {
+                                                            "type": "string"
+                                                        },
+                                                        "href": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                }
+                                            }
+                                        },
+                                        "required": [],
+                                        "additionalProperties": false
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/sessiontemplatesvalid/{session_template_id}": {
+            "parameters": [
+                {
+                    "name": "session_template_id",
+                    "in": "path",
+                    "description": "Session Template ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Validate the session template by id",
+                "description": "Validate session template by session_template_id.\nThe session_template_id corresponds to the *name*\nof the session template.\n",
+                "tags": [
+                    "v2",
+                    "sessiontemplatess"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessiontemplates",
+                "operationId": "validate_v2_sessiontemplate",
+                "responses": {
+                    "200": {
+                        "description": "Session template validity details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "Message describing errors or incompleteness in a Session Template.\n",
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The resource was not found.",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/sessiontemplates/{session_template_id}": {
+            "parameters": [
+                {
+                    "name": "session_template_id",
+                    "in": "path",
+                    "description": "Session Template ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Get session template by id",
+                "description": "Get session template by session_template_id.\nThe session_template_id corresponds to the *name*\nof the session template.\n",
+                "tags": [
+                    "v2",
+                    "sessiontemplatess"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessiontemplates",
+                "operationId": "get_v2_sessiontemplate",
+                "responses": {
+                    "200": {
+                        "description": "Session template details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which applies the data to\ngroup of components.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string",
+                                            "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
+                                            "example": "cle-1.0.0",
+                                            "minLength": 1,
+                                            "maxLength": 45,
+                                            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
+                                            "readOnly": true
+                                        },
+                                        "description": {
+                                            "type": "string",
+                                            "description": "An optional description for the session template.\n"
+                                        },
+                                        "enable_cfs": {
+                                            "type": "boolean",
+                                            "description": "Whether to enable the Configuration Framework Service (CFS).\nChoices: true/false\n",
+                                            "default": true
+                                        },
+                                        "cfs": {
+                                            "type": "object",
+                                            "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                            "properties": {
+                                                "configuration": {
+                                                    "type": "string",
+                                                    "description": "The name of configuration to be applied.\n"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "boot_sets": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "description": "A boot set is a collection of nodes defined by an explicit list, their functional\nrole, and their logical groupings. This collection of nodes is associated with one\nset of boot artifacts and optional additional records for configuration and root\nfilesystem provisioning.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The Boot Set name.\n"
+                                                    },
+                                                    "path": {
+                                                        "type": "string",
+                                                        "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
+                                                    },
+                                                    "cfs": {
+                                                        "type": "object",
+                                                        "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                                        "properties": {
+                                                            "configuration": {
+                                                                "type": "string",
+                                                                "description": "The name of configuration to be applied.\n"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
+                                                    },
+                                                    "etag": {
+                                                        "type": "string",
+                                                        "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "The kernel parameters to use to boot the nodes.\n"
+                                                    },
+                                                    "node_list": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "description": "The node list. This is an explicit mapping against hardware xnames.\n"
+                                                    },
+                                                    "node_roles_groups": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
+                                                    },
+                                                    "node_groups": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
+                                                    },
+                                                    "rootfs_provider": {
+                                                        "type": "string",
+                                                        "description": "The root file system provider.\n"
+                                                    },
+                                                    "rootfs_provider_passthrough": {
+                                                        "type": "string",
+                                                        "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "path",
+                                                    "type"
+                                                ]
+                                            }
+                                        },
+                                        "links": {
+                                            "type": "array",
+                                            "readOnly": true,
+                                            "items": {
+                                                "description": "Link to other resources",
+                                                "type": "object",
+                                                "properties": {
+                                                    "rel": {
+                                                        "type": "string"
+                                                    },
+                                                    "href": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            }
+                                        }
+                                    },
+                                    "required": [],
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The resource was not found.",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "summary": "Create session template",
+                "tags": [
+                    "v2",
+                    "sessiontemplates"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessiontemplates",
+                "operationId": "put_v2_sessiontemplate",
+                "description": "Create a new session template.",
+                "requestBody": {
+                    "description": "A JSON object for creating a session template",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which applies the data to\ngroup of components.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
+                                        "example": "cle-1.0.0",
+                                        "minLength": 1,
+                                        "maxLength": 45,
+                                        "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
+                                        "readOnly": true
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "description": "An optional description for the session template.\n"
+                                    },
+                                    "enable_cfs": {
+                                        "type": "boolean",
+                                        "description": "Whether to enable the Configuration Framework Service (CFS).\nChoices: true/false\n",
+                                        "default": true
+                                    },
+                                    "cfs": {
+                                        "type": "object",
+                                        "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                        "properties": {
+                                            "configuration": {
+                                                "type": "string",
+                                                "description": "The name of configuration to be applied.\n"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "boot_sets": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                            "description": "A boot set is a collection of nodes defined by an explicit list, their functional\nrole, and their logical groupings. This collection of nodes is associated with one\nset of boot artifacts and optional additional records for configuration and root\nfilesystem provisioning.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "The Boot Set name.\n"
+                                                },
+                                                "path": {
+                                                    "type": "string",
+                                                    "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
+                                                },
+                                                "cfs": {
+                                                    "type": "object",
+                                                    "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                                    "properties": {
+                                                        "configuration": {
+                                                            "type": "string",
+                                                            "description": "The name of configuration to be applied.\n"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "type": {
+                                                    "type": "string",
+                                                    "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
+                                                },
+                                                "etag": {
+                                                    "type": "string",
+                                                    "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
+                                                },
+                                                "kernel_parameters": {
+                                                    "type": "string",
+                                                    "description": "The kernel parameters to use to boot the nodes.\n"
+                                                },
+                                                "node_list": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "minItems": 1,
+                                                    "description": "The node list. This is an explicit mapping against hardware xnames.\n"
+                                                },
+                                                "node_roles_groups": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "minItems": 1,
+                                                    "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
+                                                },
+                                                "node_groups": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "minItems": 1,
+                                                    "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
+                                                },
+                                                "rootfs_provider": {
+                                                    "type": "string",
+                                                    "description": "The root file system provider.\n"
+                                                },
+                                                "rootfs_provider_passthrough": {
+                                                    "type": "string",
+                                                    "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
+                                                }
+                                            },
+                                            "additionalProperties": false,
+                                            "required": [
+                                                "path",
+                                                "type"
+                                            ]
+                                        }
+                                    },
+                                    "links": {
+                                        "type": "array",
+                                        "readOnly": true,
+                                        "items": {
+                                            "description": "Link to other resources",
+                                            "type": "object",
+                                            "properties": {
+                                                "rel": {
+                                                    "type": "string"
+                                                },
+                                                "href": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                },
+                                "required": [],
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Session template details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which applies the data to\ngroup of components.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string",
+                                            "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
+                                            "example": "cle-1.0.0",
+                                            "minLength": 1,
+                                            "maxLength": 45,
+                                            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
+                                            "readOnly": true
+                                        },
+                                        "description": {
+                                            "type": "string",
+                                            "description": "An optional description for the session template.\n"
+                                        },
+                                        "enable_cfs": {
+                                            "type": "boolean",
+                                            "description": "Whether to enable the Configuration Framework Service (CFS).\nChoices: true/false\n",
+                                            "default": true
+                                        },
+                                        "cfs": {
+                                            "type": "object",
+                                            "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                            "properties": {
+                                                "configuration": {
+                                                    "type": "string",
+                                                    "description": "The name of configuration to be applied.\n"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "boot_sets": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "description": "A boot set is a collection of nodes defined by an explicit list, their functional\nrole, and their logical groupings. This collection of nodes is associated with one\nset of boot artifacts and optional additional records for configuration and root\nfilesystem provisioning.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The Boot Set name.\n"
+                                                    },
+                                                    "path": {
+                                                        "type": "string",
+                                                        "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
+                                                    },
+                                                    "cfs": {
+                                                        "type": "object",
+                                                        "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                                        "properties": {
+                                                            "configuration": {
+                                                                "type": "string",
+                                                                "description": "The name of configuration to be applied.\n"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
+                                                    },
+                                                    "etag": {
+                                                        "type": "string",
+                                                        "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "The kernel parameters to use to boot the nodes.\n"
+                                                    },
+                                                    "node_list": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "description": "The node list. This is an explicit mapping against hardware xnames.\n"
+                                                    },
+                                                    "node_roles_groups": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
+                                                    },
+                                                    "node_groups": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
+                                                    },
+                                                    "rootfs_provider": {
+                                                        "type": "string",
+                                                        "description": "The root file system provider.\n"
+                                                    },
+                                                    "rootfs_provider_passthrough": {
+                                                        "type": "string",
+                                                        "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "path",
+                                                    "type"
+                                                ]
+                                            }
+                                        },
+                                        "links": {
+                                            "type": "array",
+                                            "readOnly": true,
+                                            "items": {
+                                                "description": "Link to other resources",
+                                                "type": "object",
+                                                "properties": {
+                                                    "rel": {
+                                                        "type": "string"
+                                                    },
+                                                    "href": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            }
+                                        }
+                                    },
+                                    "required": [],
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "summary": "Update a session template",
+                "tags": [
+                    "v2",
+                    "sessiontemplates"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessiontemplates",
+                "operationId": "patch_v2_sessiontemplate",
+                "requestBody": {
+                    "description": "A JSON object for updating a session template",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which applies the data to\ngroup of components.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
+                                        "example": "cle-1.0.0",
+                                        "minLength": 1,
+                                        "maxLength": 45,
+                                        "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
+                                        "readOnly": true
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "description": "An optional description for the session template.\n"
+                                    },
+                                    "enable_cfs": {
+                                        "type": "boolean",
+                                        "description": "Whether to enable the Configuration Framework Service (CFS).\nChoices: true/false\n",
+                                        "default": true
+                                    },
+                                    "cfs": {
+                                        "type": "object",
+                                        "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                        "properties": {
+                                            "configuration": {
+                                                "type": "string",
+                                                "description": "The name of configuration to be applied.\n"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "boot_sets": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                            "description": "A boot set is a collection of nodes defined by an explicit list, their functional\nrole, and their logical groupings. This collection of nodes is associated with one\nset of boot artifacts and optional additional records for configuration and root\nfilesystem provisioning.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "description": "The Boot Set name.\n"
+                                                },
+                                                "path": {
+                                                    "type": "string",
+                                                    "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
+                                                },
+                                                "cfs": {
+                                                    "type": "object",
+                                                    "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                                    "properties": {
+                                                        "configuration": {
+                                                            "type": "string",
+                                                            "description": "The name of configuration to be applied.\n"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "type": {
+                                                    "type": "string",
+                                                    "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
+                                                },
+                                                "etag": {
+                                                    "type": "string",
+                                                    "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
+                                                },
+                                                "kernel_parameters": {
+                                                    "type": "string",
+                                                    "description": "The kernel parameters to use to boot the nodes.\n"
+                                                },
+                                                "node_list": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "minItems": 1,
+                                                    "description": "The node list. This is an explicit mapping against hardware xnames.\n"
+                                                },
+                                                "node_roles_groups": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "minItems": 1,
+                                                    "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
+                                                },
+                                                "node_groups": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "minItems": 1,
+                                                    "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
+                                                },
+                                                "rootfs_provider": {
+                                                    "type": "string",
+                                                    "description": "The root file system provider.\n"
+                                                },
+                                                "rootfs_provider_passthrough": {
+                                                    "type": "string",
+                                                    "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
+                                                }
+                                            },
+                                            "additionalProperties": false,
+                                            "required": [
+                                                "path",
+                                                "type"
+                                            ]
+                                        }
+                                    },
+                                    "links": {
+                                        "type": "array",
+                                        "readOnly": true,
+                                        "items": {
+                                            "description": "Link to other resources",
+                                            "type": "object",
+                                            "properties": {
+                                                "rel": {
+                                                    "type": "string"
+                                                },
+                                                "href": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                },
+                                "required": [],
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Session template details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which applies the data to\ngroup of components.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string",
+                                            "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
+                                            "example": "cle-1.0.0",
+                                            "minLength": 1,
+                                            "maxLength": 45,
+                                            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
+                                            "readOnly": true
+                                        },
+                                        "description": {
+                                            "type": "string",
+                                            "description": "An optional description for the session template.\n"
+                                        },
+                                        "enable_cfs": {
+                                            "type": "boolean",
+                                            "description": "Whether to enable the Configuration Framework Service (CFS).\nChoices: true/false\n",
+                                            "default": true
+                                        },
+                                        "cfs": {
+                                            "type": "object",
+                                            "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                            "properties": {
+                                                "configuration": {
+                                                    "type": "string",
+                                                    "description": "The name of configuration to be applied.\n"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "boot_sets": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "description": "A boot set is a collection of nodes defined by an explicit list, their functional\nrole, and their logical groupings. This collection of nodes is associated with one\nset of boot artifacts and optional additional records for configuration and root\nfilesystem provisioning.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The Boot Set name.\n"
+                                                    },
+                                                    "path": {
+                                                        "type": "string",
+                                                        "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
+                                                    },
+                                                    "cfs": {
+                                                        "type": "object",
+                                                        "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                                        "properties": {
+                                                            "configuration": {
+                                                                "type": "string",
+                                                                "description": "The name of configuration to be applied.\n"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
+                                                    },
+                                                    "etag": {
+                                                        "type": "string",
+                                                        "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "The kernel parameters to use to boot the nodes.\n"
+                                                    },
+                                                    "node_list": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "description": "The node list. This is an explicit mapping against hardware xnames.\n"
+                                                    },
+                                                    "node_roles_groups": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
+                                                    },
+                                                    "node_groups": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
+                                                    },
+                                                    "rootfs_provider": {
+                                                        "type": "string",
+                                                        "description": "The root file system provider.\n"
+                                                    },
+                                                    "rootfs_provider_passthrough": {
+                                                        "type": "string",
+                                                        "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "path",
+                                                    "type"
+                                                ]
+                                            }
+                                        },
+                                        "links": {
+                                            "type": "array",
+                                            "readOnly": true,
+                                            "items": {
+                                                "description": "Link to other resources",
+                                                "type": "object",
+                                                "properties": {
+                                                    "rel": {
+                                                        "type": "string"
+                                                    },
+                                                    "href": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            }
+                                        }
+                                    },
+                                    "required": [],
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete a session template",
+                "description": "Delete a session template.",
+                "tags": [
+                    "v2",
+                    "sessiontemplates"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessiontemplates",
+                "operationId": "delete_v2_sessiontemplate",
+                "responses": {
+                    "204": {
+                        "description": "The resource was deleted."
+                    },
+                    "404": {
+                        "description": "The resource was not found.",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/sessiontemplatetemplate": {
+            "get": {
+                "summary": "Get an example session template.",
+                "description": "Returns a skeleton of a session template, which can be\nused as a starting point for users creating their own\nsession templates.\n",
+                "tags": [
+                    "v2",
+                    "sessiontemplates"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessiontemplates",
+                "operationId": "get_v2_sessiontemplatetemplate",
+                "responses": {
+                    "200": {
+                        "description": "Session template details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which applies the data to\ngroup of components.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string",
+                                            "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
+                                            "example": "cle-1.0.0",
+                                            "minLength": 1,
+                                            "maxLength": 45,
+                                            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
+                                            "readOnly": true
+                                        },
+                                        "description": {
+                                            "type": "string",
+                                            "description": "An optional description for the session template.\n"
+                                        },
+                                        "enable_cfs": {
+                                            "type": "boolean",
+                                            "description": "Whether to enable the Configuration Framework Service (CFS).\nChoices: true/false\n",
+                                            "default": true
+                                        },
+                                        "cfs": {
+                                            "type": "object",
+                                            "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                            "properties": {
+                                                "configuration": {
+                                                    "type": "string",
+                                                    "description": "The name of configuration to be applied.\n"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "boot_sets": {
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "description": "A boot set is a collection of nodes defined by an explicit list, their functional\nrole, and their logical groupings. This collection of nodes is associated with one\nset of boot artifacts and optional additional records for configuration and root\nfilesystem provisioning.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The Boot Set name.\n"
+                                                    },
+                                                    "path": {
+                                                        "type": "string",
+                                                        "description": "A path identifying the metadata describing the components of the boot image. This could be a URI, URL, etc.\nIt will be processed based on the type attribute.\n"
+                                                    },
+                                                    "cfs": {
+                                                        "type": "object",
+                                                        "description": "CFS Parameters is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a boot set.\n",
+                                                        "properties": {
+                                                            "configuration": {
+                                                                "type": "string",
+                                                                "description": "The name of configuration to be applied.\n"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The mime type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n"
+                                                    },
+                                                    "etag": {
+                                                        "type": "string",
+                                                        "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.\n"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "The kernel parameters to use to boot the nodes.\n"
+                                                    },
+                                                    "node_list": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "description": "The node list. This is an explicit mapping against hardware xnames.\n"
+                                                    },
+                                                    "node_roles_groups": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "description": "The node roles list. Allows actions against nodes with associated roles. Roles are defined in SMD.\n"
+                                                    },
+                                                    "node_groups": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "description": "The node groups list. Allows actions against associated nodes by logical groupings. Logical groups are user defined groups in SMD.\n"
+                                                    },
+                                                    "rootfs_provider": {
+                                                        "type": "string",
+                                                        "description": "The root file system provider.\n"
+                                                    },
+                                                    "rootfs_provider_passthrough": {
+                                                        "type": "string",
+                                                        "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "path",
+                                                    "type"
+                                                ]
+                                            }
+                                        },
+                                        "links": {
+                                            "type": "array",
+                                            "readOnly": true,
+                                            "items": {
+                                                "description": "Link to other resources",
+                                                "type": "object",
+                                                "properties": {
+                                                    "rel": {
+                                                        "type": "string"
+                                                    },
+                                                    "href": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            }
+                                        }
+                                    },
+                                    "required": [],
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/sessions": {
+            "post": {
+                "summary": "Create a session",
+                "description": "The creation of a session performs the operation\nspecified in the SessionCreateRequest\non the boot set(s) defined in the session template.\n",
+                "tags": [
+                    "v2",
+                    "sessions"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessions",
+                "operationId": "post_v2_session",
+                "requestBody": {
+                    "description": "The information to create a session",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "description": "A Session Creation object\n",
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Name of the session. A uuid name is generated if a name is not provided.",
+                                        "example": "session-20190728032600",
+                                        "minLength": 1,
+                                        "maxLength": 45,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                                    },
+                                    "operation": {
+                                        "type": "string",
+                                        "enum": [
+                                            "boot",
+                                            "reboot",
+                                            "shutdown"
+                                        ],
+                                        "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                                    },
+                                    "template_name": {
+                                        "type": "string",
+                                        "description": "The name of the Session Template",
+                                        "example": "my-session-template",
+                                        "format": "string"
+                                    },
+                                    "limit": {
+                                        "type": "string",
+                                        "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                    },
+                                    "stage": {
+                                        "type": "boolean",
+                                        "description": "Set to force nodes to reboot even if they are already in the desired state.\n",
+                                        "default": false
+                                    }
+                                },
+                                "required": [
+                                    "operation",
+                                    "template_name"
+                                ],
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Session details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "A Session object\n\n## Link Relationships\n\n* self : The session object\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string",
+                                            "description": "Name of the session.\n"
+                                        },
+                                        "operation": {
+                                            "type": "string",
+                                            "enum": [
+                                                "boot",
+                                                "reboot",
+                                                "shutdown"
+                                            ],
+                                            "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                                        },
+                                        "template_name": {
+                                            "type": "string",
+                                            "description": "The name of the Session Template",
+                                            "example": "my-session-template",
+                                            "format": "string"
+                                        },
+                                        "limit": {
+                                            "type": "string",
+                                            "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                        },
+                                        "stage": {
+                                            "type": "boolean",
+                                            "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                                        },
+                                        "components": {
+                                            "type": "string",
+                                            "description": "A comma separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
+                                        },
+                                        "status": {
+                                            "type": "object",
+                                            "description": "Information on the status of a session.\n",
+                                            "properties": {
+                                                "start_time": {
+                                                    "type": "string",
+                                                    "description": "When the session was created.\n"
+                                                },
+                                                "end_time": {
+                                                    "type": "string",
+                                                    "description": "When the session completed.\n"
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "pending",
+                                                        "running",
+                                                        "complete"
+                                                    ],
+                                                    "description": "The status of a session.\n"
+                                                },
+                                                "error": {
+                                                    "type": "string",
+                                                    "description": "Error which prevented the session from running\n"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "summary": "List sessions",
+                "description": "List all sessions, including those in progress and those complete.\n",
+                "tags": [
+                    "v2",
+                    "sessions"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessions",
+                "operationId": "get_v2_sessions",
+                "parameters": [
+                    {
+                        "name": "min_age",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query",
+                        "description": "Return only sessions older than the given age.  Age is given in the format \"1d\" or \"6h\""
+                    },
+                    {
+                        "name": "max_age",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query",
+                        "description": "Return only sessions younger than the given age.  Age is given in the format \"1d\" or \"6h\""
+                    },
+                    {
+                        "name": "status",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "pending",
+                                "running",
+                                "complete"
+                            ]
+                        },
+                        "in": "query",
+                        "description": "Return only sessions with the given status."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Session details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An array of sessions.",
+                                    "type": "array",
+                                    "items": {
+                                        "description": "A Session object\n\n## Link Relationships\n\n* self : The session object\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "Name of the session.\n"
+                                            },
+                                            "operation": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "boot",
+                                                    "reboot",
+                                                    "shutdown"
+                                                ],
+                                                "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                                            },
+                                            "template_name": {
+                                                "type": "string",
+                                                "description": "The name of the Session Template",
+                                                "example": "my-session-template",
+                                                "format": "string"
+                                            },
+                                            "limit": {
+                                                "type": "string",
+                                                "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                            },
+                                            "stage": {
+                                                "type": "boolean",
+                                                "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                                            },
+                                            "components": {
+                                                "type": "string",
+                                                "description": "A comma separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
+                                            },
+                                            "status": {
+                                                "type": "object",
+                                                "description": "Information on the status of a session.\n",
+                                                "properties": {
+                                                    "start_time": {
+                                                        "type": "string",
+                                                        "description": "When the session was created.\n"
+                                                    },
+                                                    "end_time": {
+                                                        "type": "string",
+                                                        "description": "When the session completed.\n"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "pending",
+                                                            "running",
+                                                            "complete"
+                                                        ],
+                                                        "description": "The status of a session.\n"
+                                                    },
+                                                    "error": {
+                                                        "type": "string",
+                                                        "description": "Error which prevented the session from running\n"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete multiple sessions.",
+                "tags": [
+                    "v2",
+                    "sessions"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessions",
+                "operationId": "delete_v2_sessions",
+                "parameters": [
+                    {
+                        "name": "min_age",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query",
+                        "description": "Return only sessions older than the given age.  Age is given in the format \"1d\" or \"6h\""
+                    },
+                    {
+                        "name": "max_age",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query",
+                        "description": "Return only sessions younger than the given age.  Age is given in the format \"1d\" or \"6h\""
+                    },
+                    {
+                        "name": "status",
+                        "schema": {
+                            "enum": [
+                                "pending",
+                                "running",
+                                "complete"
+                            ],
+                            "type": "string"
+                        },
+                        "in": "query",
+                        "description": "Return only sessions with the given status."
+                    }
+                ],
+                "description": "Delete multiple sessions.  If filters are provided, only sessions matching all filters will be deleted.  By default only completed sessions will be deleted.",
+                "responses": {
+                    "204": {
+                        "description": "The resource was deleted."
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/sessions/{session_id}": {
+            "get": {
+                "summary": "Get session details by id",
+                "description": "Get session details by session_id.",
+                "tags": [
+                    "v2",
+                    "sessions"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessions",
+                "operationId": "get_v2_session",
+                "responses": {
+                    "200": {
+                        "description": "Session details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "A Session object\n\n## Link Relationships\n\n* self : The session object\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string",
+                                            "description": "Name of the session.\n"
+                                        },
+                                        "operation": {
+                                            "type": "string",
+                                            "enum": [
+                                                "boot",
+                                                "reboot",
+                                                "shutdown"
+                                            ],
+                                            "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                                        },
+                                        "template_name": {
+                                            "type": "string",
+                                            "description": "The name of the Session Template",
+                                            "example": "my-session-template",
+                                            "format": "string"
+                                        },
+                                        "limit": {
+                                            "type": "string",
+                                            "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                        },
+                                        "stage": {
+                                            "type": "boolean",
+                                            "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                                        },
+                                        "components": {
+                                            "type": "string",
+                                            "description": "A comma separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
+                                        },
+                                        "status": {
+                                            "type": "object",
+                                            "description": "Information on the status of a session.\n",
+                                            "properties": {
+                                                "start_time": {
+                                                    "type": "string",
+                                                    "description": "When the session was created.\n"
+                                                },
+                                                "end_time": {
+                                                    "type": "string",
+                                                    "description": "When the session completed.\n"
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "pending",
+                                                        "running",
+                                                        "complete"
+                                                    ],
+                                                    "description": "The status of a session.\n"
+                                                },
+                                                "error": {
+                                                    "type": "string",
+                                                    "description": "Error which prevented the session from running\n"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The resource was not found.",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "summary": "Update a single session",
+                "tags": [
+                    "v2",
+                    "sessions"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessions",
+                "description": "Update the state for a given session in the BOS database",
+                "operationId": "patch_v2_session",
+                "requestBody": {
+                    "description": "The state for a single session",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "description": "A Session object\n\n## Link Relationships\n\n* self : The session object\n",
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Name of the session.\n"
+                                    },
+                                    "operation": {
+                                        "type": "string",
+                                        "enum": [
+                                            "boot",
+                                            "reboot",
+                                            "shutdown"
+                                        ],
+                                        "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                                    },
+                                    "template_name": {
+                                        "type": "string",
+                                        "description": "The name of the Session Template",
+                                        "example": "my-session-template",
+                                        "format": "string"
+                                    },
+                                    "limit": {
+                                        "type": "string",
+                                        "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                    },
+                                    "stage": {
+                                        "type": "boolean",
+                                        "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                                    },
+                                    "components": {
+                                        "type": "string",
+                                        "description": "A comma separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
+                                    },
+                                    "status": {
+                                        "type": "object",
+                                        "description": "Information on the status of a session.\n",
+                                        "properties": {
+                                            "start_time": {
+                                                "type": "string",
+                                                "description": "When the session was created.\n"
+                                            },
+                                            "end_time": {
+                                                "type": "string",
+                                                "description": "When the session completed.\n"
+                                            },
+                                            "status": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "pending",
+                                                    "running",
+                                                    "complete"
+                                                ],
+                                                "description": "The status of a session.\n"
+                                            },
+                                            "error": {
+                                                "type": "string",
+                                                "description": "Error which prevented the session from running\n"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Session details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "A Session object\n\n## Link Relationships\n\n* self : The session object\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string",
+                                            "description": "Name of the session.\n"
+                                        },
+                                        "operation": {
+                                            "type": "string",
+                                            "enum": [
+                                                "boot",
+                                                "reboot",
+                                                "shutdown"
+                                            ],
+                                            "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                                        },
+                                        "template_name": {
+                                            "type": "string",
+                                            "description": "The name of the Session Template",
+                                            "example": "my-session-template",
+                                            "format": "string"
+                                        },
+                                        "limit": {
+                                            "type": "string",
+                                            "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                        },
+                                        "stage": {
+                                            "type": "boolean",
+                                            "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                                        },
+                                        "components": {
+                                            "type": "string",
+                                            "description": "A comma separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
+                                        },
+                                        "status": {
+                                            "type": "object",
+                                            "description": "Information on the status of a session.\n",
+                                            "properties": {
+                                                "start_time": {
+                                                    "type": "string",
+                                                    "description": "When the session was created.\n"
+                                                },
+                                                "end_time": {
+                                                    "type": "string",
+                                                    "description": "When the session completed.\n"
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "pending",
+                                                        "running",
+                                                        "complete"
+                                                    ],
+                                                    "description": "The status of a session.\n"
+                                                },
+                                                "error": {
+                                                    "type": "string",
+                                                    "description": "Error which prevented the session from running\n"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The resource was not found.",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete session by id",
+                "description": "Delete session by session_id.",
+                "tags": [
+                    "v2",
+                    "sessions"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessions",
+                "operationId": "delete_v2_session",
+                "responses": {
+                    "204": {
+                        "description": "The resource was deleted."
+                    },
+                    "404": {
+                        "description": "The resource was not found.",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "session_id",
+                    "in": "path",
+                    "description": "Session ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "/v2/sessions/{session_id}/status": {
+            "get": {
+                "summary": "Get session extended status information by id",
+                "description": "Get session extended status information by id",
+                "tags": [
+                    "v2",
+                    "sessions"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessions",
+                "operationId": "get_v2_session_status",
+                "responses": {
+                    "200": {
+                        "description": "Session status details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "Detailed information on the status of a session.\n",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "pending",
+                                                "running",
+                                                "complete"
+                                            ],
+                                            "description": "The status of a session.\n"
+                                        },
+                                        "managed_components_count": {
+                                            "type": "integer",
+                                            "description": "The count of components currently managed by this session\n"
+                                        },
+                                        "phases": {
+                                            "type": "object",
+                                            "description": "Detailed information on the phases of a session.\n",
+                                            "properties": {
+                                                "percent_complete": {
+                                                    "type": "float",
+                                                    "description": "The percent of components currently in a completed/stable state\n"
+                                                },
+                                                "percent_powering_on": {
+                                                    "type": "float",
+                                                    "description": "The percent of components currently in the powering-on phase\n"
+                                                },
+                                                "percent_powering_off": {
+                                                    "type": "float",
+                                                    "description": "The percent of components currently in the powering-off phase\n"
+                                                },
+                                                "percent_configuring": {
+                                                    "type": "float",
+                                                    "description": "The percent of components currently in the configuring phase\n"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "percent_successful": {
+                                            "type": "float",
+                                            "description": "The percent of components currently in a successful state\n"
+                                        },
+                                        "percent_failed": {
+                                            "type": "float",
+                                            "description": "The percent of components currently in a failed state\n"
+                                        },
+                                        "percent_staged": {
+                                            "type": "float",
+                                            "description": "The percent of components currently still staged for this session\n"
+                                        },
+                                        "error_summary": {
+                                            "type": "object",
+                                            "description": "A summary of the errors currently listed by all components\n"
+                                        },
+                                        "timing": {
+                                            "type": "object",
+                                            "description": "Detailed information on the timing of a session.\n",
+                                            "properties": {
+                                                "start_time": {
+                                                    "type": "string",
+                                                    "description": "When the session was created.\n"
+                                                },
+                                                "end_time": {
+                                                    "type": "string",
+                                                    "description": "When the session completed.\n"
+                                                },
+                                                "duration": {
+                                                    "type": "string",
+                                                    "description": "The current duration of the on-going session or final duration of the completed session.\n"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The resource was not found.",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "summary": "Saves the current session to database",
+                "tags": [
+                    "v2",
+                    "sessions",
+                    "cli_ignore"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.sessions",
+                "description": "Saves the current session to database.  For use at session completion.",
+                "operationId": "save_v2_session_status",
+                "responses": {
+                    "200": {
+                        "description": "Session details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "A Session object\n\n## Link Relationships\n\n* self : The session object\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string",
+                                            "description": "Name of the session.\n"
+                                        },
+                                        "operation": {
+                                            "type": "string",
+                                            "enum": [
+                                                "boot",
+                                                "reboot",
+                                                "shutdown"
+                                            ],
+                                            "description": "A Session represents a desired state that is being applied to a group of components.  Sessions run until all components it manages have either been disabled due to completion, or until all components are managed by other newer sessions.\nOperation -- An operation to perform on nodes in this session.\n    Boot                 Applies the template to the components and boots/reboots if necessary.\n    Reboot               Applies the template to the components guarantees a reboot.\n    Shutdown             Power down nodes that are on.\n"
+                                        },
+                                        "template_name": {
+                                            "type": "string",
+                                            "description": "The name of the Session Template",
+                                            "example": "my-session-template",
+                                            "format": "string"
+                                        },
+                                        "limit": {
+                                            "type": "string",
+                                            "description": "A comma separated of nodes, groups or roles to which the session will be limited. Components are treated as OR operations unless preceded by \"&\" for AND or \"!\" for NOT.\n"
+                                        },
+                                        "stage": {
+                                            "type": "boolean",
+                                            "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                                        },
+                                        "components": {
+                                            "type": "string",
+                                            "description": "A comma separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
+                                        },
+                                        "status": {
+                                            "type": "object",
+                                            "description": "Information on the status of a session.\n",
+                                            "properties": {
+                                                "start_time": {
+                                                    "type": "string",
+                                                    "description": "When the session was created.\n"
+                                                },
+                                                "end_time": {
+                                                    "type": "string",
+                                                    "description": "When the session completed.\n"
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "pending",
+                                                        "running",
+                                                        "complete"
+                                                    ],
+                                                    "description": "The status of a session.\n"
+                                                },
+                                                "error": {
+                                                    "type": "string",
+                                                    "description": "Error which prevented the session from running\n"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The resource was not found.",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "session_id",
+                    "in": "path",
+                    "description": "Session ID",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "/v2/components": {
+            "get": {
+                "summary": "Retrieve the state of a collection of components",
+                "tags": [
+                    "v2",
+                    "components"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.components",
+                "description": "Retrieve the full collection of components in the form of a ComponentArray. Full results can also be filtered by query parameters. Only the first filter parameter of each type is used and the parameters are applied in an AND fashion. If the collection is empty or the filters have no match, an empty array is returned.",
+                "operationId": "get_v2_components",
+                "parameters": [
+                    {
+                        "name": "ids",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query",
+                        "description": "Retrieve the components with the given id (e.g. xname for hardware components). Can be chained for selecting groups of components."
+                    },
+                    {
+                        "name": "session",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query",
+                        "description": "Retrieve the components with the given session id."
+                    },
+                    {
+                        "name": "staged_session",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query",
+                        "description": "Retrieve the components with the given staged session id."
+                    },
+                    {
+                        "name": "enabled",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "in": "query",
+                        "description": "Retrieve the components with the \"enabled\" state."
+                    },
+                    {
+                        "name": "phase",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query",
+                        "description": "Retrieve the components in the given phase."
+                    },
+                    {
+                        "name": "status",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query",
+                        "description": "Retrieve the components with the given status."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "A collection of component states",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An array of component states.",
+                                    "type": "array",
+                                    "items": {
+                                        "description": "The current and desired artifacts state for a component.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "description": "The component's id. e.g. xname for hardware components"
+                                            },
+                                            "actual_state": {
+                                                "description": "The desired boot artifacts and configuration for a component\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "boot_artifacts": {
+                                                        "description": "A collection of boot artifacts.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kernel": {
+                                                                "type": "string",
+                                                                "description": "An md5sum hash of the kernel ID"
+                                                            },
+                                                            "kernel_parameters": {
+                                                                "type": "string",
+                                                                "description": "Kernel parameters"
+                                                            },
+                                                            "initrd": {
+                                                                "type": "string",
+                                                                "description": "Initrd ID"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "bss_token": {
+                                                        "type": "string",
+                                                        "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                    },
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    }
+                                                }
+                                            },
+                                            "desired_state": {
+                                                "description": "The desired boot artifacts and configuration for a component\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "boot_artifacts": {
+                                                        "description": "A collection of boot artifacts.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kernel": {
+                                                                "type": "string",
+                                                                "description": "An md5sum hash of the kernel ID"
+                                                            },
+                                                            "kernel_parameters": {
+                                                                "type": "string",
+                                                                "description": "Kernel parameters"
+                                                            },
+                                                            "initrd": {
+                                                                "type": "string",
+                                                                "description": "Initrd ID"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "configuration": {
+                                                        "type": "string",
+                                                        "description": "A CFS configuration ID."
+                                                    },
+                                                    "bss_token": {
+                                                        "type": "string",
+                                                        "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                    },
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "staged_state": {
+                                                "description": "The desired boot artifacts and configuration for a component\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "boot_artifacts": {
+                                                        "description": "A collection of boot artifacts.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kernel": {
+                                                                "type": "string",
+                                                                "description": "An md5sum hash of the kernel ID"
+                                                            },
+                                                            "kernel_parameters": {
+                                                                "type": "string",
+                                                                "description": "Kernel parameters"
+                                                            },
+                                                            "initrd": {
+                                                                "type": "string",
+                                                                "description": "Initrd ID"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "configuration": {
+                                                        "type": "string",
+                                                        "description": "A CFS configuration ID."
+                                                    },
+                                                    "session": {
+                                                        "type": "string",
+                                                        "description": "A session which can be triggered at a later time against this component."
+                                                    },
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "last_action": {
+                                                "description": "Information on the most recent action taken against the node.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    },
+                                                    "action": {
+                                                        "type": "string",
+                                                        "description": "A description of the most recent operator/action to impact the component."
+                                                    },
+                                                    "num_attempts": {
+                                                        "type": "integer",
+                                                        "description": "How many attempts have been made for this action."
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "status": {
+                                                "description": "Status information for the component",
+                                                "type": "object",
+                                                "properties": {
+                                                    "phase": {
+                                                        "type": "string",
+                                                        "description": "The current phase of the component in the boot process."
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "description": "The current status of the component.  More detailed than phase.",
+                                                        "readOnly": true
+                                                    },
+                                                    "status_override": {
+                                                        "type": "string",
+                                                        "description": "If set, this will override the status value."
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "enabled": {
+                                                "type": "boolean",
+                                                "description": "A flag indicating if actions should be taken for this component."
+                                            },
+                                            "error": {
+                                                "type": "string",
+                                                "description": "A description of the most recent error to impact the component."
+                                            },
+                                            "session": {
+                                                "type": "string",
+                                                "description": "The session responsible for the component's current state"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "summary": "Add or Replace a collection of components",
+                "tags": [
+                    "v2",
+                    "components",
+                    "cli_ignore"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.components",
+                "description": "Update the state for a collection of components in the BOS database",
+                "operationId": "put_v2_components",
+                "requestBody": {
+                    "description": "The state for an array of components",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "description": "An array of component states.",
+                                "type": "array",
+                                "items": {
+                                    "description": "The current and desired artifacts state for a component.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": "The component's id. e.g. xname for hardware components"
+                                        },
+                                        "actual_state": {
+                                            "description": "The desired boot artifacts and configuration for a component\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "boot_artifacts": {
+                                                    "description": "A collection of boot artifacts.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "kernel": {
+                                                            "type": "string",
+                                                            "description": "An md5sum hash of the kernel ID"
+                                                        },
+                                                        "kernel_parameters": {
+                                                            "type": "string",
+                                                            "description": "Kernel parameters"
+                                                        },
+                                                        "initrd": {
+                                                            "type": "string",
+                                                            "description": "Initrd ID"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "bss_token": {
+                                                    "type": "string",
+                                                    "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                },
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                }
+                                            }
+                                        },
+                                        "desired_state": {
+                                            "description": "The desired boot artifacts and configuration for a component\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "boot_artifacts": {
+                                                    "description": "A collection of boot artifacts.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "kernel": {
+                                                            "type": "string",
+                                                            "description": "An md5sum hash of the kernel ID"
+                                                        },
+                                                        "kernel_parameters": {
+                                                            "type": "string",
+                                                            "description": "Kernel parameters"
+                                                        },
+                                                        "initrd": {
+                                                            "type": "string",
+                                                            "description": "Initrd ID"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "configuration": {
+                                                    "type": "string",
+                                                    "description": "A CFS configuration ID."
+                                                },
+                                                "bss_token": {
+                                                    "type": "string",
+                                                    "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                },
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "staged_state": {
+                                            "description": "The desired boot artifacts and configuration for a component\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "boot_artifacts": {
+                                                    "description": "A collection of boot artifacts.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "kernel": {
+                                                            "type": "string",
+                                                            "description": "An md5sum hash of the kernel ID"
+                                                        },
+                                                        "kernel_parameters": {
+                                                            "type": "string",
+                                                            "description": "Kernel parameters"
+                                                        },
+                                                        "initrd": {
+                                                            "type": "string",
+                                                            "description": "Initrd ID"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "configuration": {
+                                                    "type": "string",
+                                                    "description": "A CFS configuration ID."
+                                                },
+                                                "session": {
+                                                    "type": "string",
+                                                    "description": "A session which can be triggered at a later time against this component."
+                                                },
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "last_action": {
+                                            "description": "Information on the most recent action taken against the node.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                },
+                                                "action": {
+                                                    "type": "string",
+                                                    "description": "A description of the most recent operator/action to impact the component."
+                                                },
+                                                "num_attempts": {
+                                                    "type": "integer",
+                                                    "description": "How many attempts have been made for this action."
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "status": {
+                                            "description": "Status information for the component",
+                                            "type": "object",
+                                            "properties": {
+                                                "phase": {
+                                                    "type": "string",
+                                                    "description": "The current phase of the component in the boot process."
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "The current status of the component.  More detailed than phase.",
+                                                    "readOnly": true
+                                                },
+                                                "status_override": {
+                                                    "type": "string",
+                                                    "description": "If set, this will override the status value."
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "description": "A flag indicating if actions should be taken for this component."
+                                        },
+                                        "error": {
+                                            "type": "string",
+                                            "description": "A description of the most recent error to impact the component."
+                                        },
+                                        "session": {
+                                            "type": "string",
+                                            "description": "The session responsible for the component's current state"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "A collection of component states",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An array of component states.",
+                                    "type": "array",
+                                    "items": {
+                                        "description": "The current and desired artifacts state for a component.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "description": "The component's id. e.g. xname for hardware components"
+                                            },
+                                            "actual_state": {
+                                                "description": "The desired boot artifacts and configuration for a component\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "boot_artifacts": {
+                                                        "description": "A collection of boot artifacts.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kernel": {
+                                                                "type": "string",
+                                                                "description": "An md5sum hash of the kernel ID"
+                                                            },
+                                                            "kernel_parameters": {
+                                                                "type": "string",
+                                                                "description": "Kernel parameters"
+                                                            },
+                                                            "initrd": {
+                                                                "type": "string",
+                                                                "description": "Initrd ID"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "bss_token": {
+                                                        "type": "string",
+                                                        "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                    },
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    }
+                                                }
+                                            },
+                                            "desired_state": {
+                                                "description": "The desired boot artifacts and configuration for a component\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "boot_artifacts": {
+                                                        "description": "A collection of boot artifacts.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kernel": {
+                                                                "type": "string",
+                                                                "description": "An md5sum hash of the kernel ID"
+                                                            },
+                                                            "kernel_parameters": {
+                                                                "type": "string",
+                                                                "description": "Kernel parameters"
+                                                            },
+                                                            "initrd": {
+                                                                "type": "string",
+                                                                "description": "Initrd ID"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "configuration": {
+                                                        "type": "string",
+                                                        "description": "A CFS configuration ID."
+                                                    },
+                                                    "bss_token": {
+                                                        "type": "string",
+                                                        "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                    },
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "staged_state": {
+                                                "description": "The desired boot artifacts and configuration for a component\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "boot_artifacts": {
+                                                        "description": "A collection of boot artifacts.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kernel": {
+                                                                "type": "string",
+                                                                "description": "An md5sum hash of the kernel ID"
+                                                            },
+                                                            "kernel_parameters": {
+                                                                "type": "string",
+                                                                "description": "Kernel parameters"
+                                                            },
+                                                            "initrd": {
+                                                                "type": "string",
+                                                                "description": "Initrd ID"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "configuration": {
+                                                        "type": "string",
+                                                        "description": "A CFS configuration ID."
+                                                    },
+                                                    "session": {
+                                                        "type": "string",
+                                                        "description": "A session which can be triggered at a later time against this component."
+                                                    },
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "last_action": {
+                                                "description": "Information on the most recent action taken against the node.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    },
+                                                    "action": {
+                                                        "type": "string",
+                                                        "description": "A description of the most recent operator/action to impact the component."
+                                                    },
+                                                    "num_attempts": {
+                                                        "type": "integer",
+                                                        "description": "How many attempts have been made for this action."
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "status": {
+                                                "description": "Status information for the component",
+                                                "type": "object",
+                                                "properties": {
+                                                    "phase": {
+                                                        "type": "string",
+                                                        "description": "The current phase of the component in the boot process."
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "description": "The current status of the component.  More detailed than phase.",
+                                                        "readOnly": true
+                                                    },
+                                                    "status_override": {
+                                                        "type": "string",
+                                                        "description": "If set, this will override the status value."
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "enabled": {
+                                                "type": "boolean",
+                                                "description": "A flag indicating if actions should be taken for this component."
+                                            },
+                                            "error": {
+                                                "type": "string",
+                                                "description": "A description of the most recent error to impact the component."
+                                            },
+                                            "session": {
+                                                "type": "string",
+                                                "description": "The session responsible for the component's current state"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "summary": "Update a collection of components",
+                "tags": [
+                    "v2",
+                    "components",
+                    "cli_ignore"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.components",
+                "description": "Update the state for a collection of components in the BOS database",
+                "operationId": "patch_v2_components",
+                "requestBody": {
+                    "description": "The state for an array of components",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "description": "Information for patching multiple components.",
+                                        "type": "object",
+                                        "properties": {
+                                            "patch": {
+                                                "description": "The current and desired artifacts state for a component.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string",
+                                                        "description": "The component's id. e.g. xname for hardware components"
+                                                    },
+                                                    "actual_state": {
+                                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "boot_artifacts": {
+                                                                "description": "A collection of boot artifacts.\n",
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "kernel": {
+                                                                        "type": "string",
+                                                                        "description": "An md5sum hash of the kernel ID"
+                                                                    },
+                                                                    "kernel_parameters": {
+                                                                        "type": "string",
+                                                                        "description": "Kernel parameters"
+                                                                    },
+                                                                    "initrd": {
+                                                                        "type": "string",
+                                                                        "description": "Initrd ID"
+                                                                    }
+                                                                },
+                                                                "additionalProperties": false
+                                                            },
+                                                            "bss_token": {
+                                                                "type": "string",
+                                                                "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                            },
+                                                            "last_updated": {
+                                                                "type": "string",
+                                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                                "example": "2019-07-28T03:26:00Z",
+                                                                "format": "date-time",
+                                                                "readOnly": true
+                                                            }
+                                                        }
+                                                    },
+                                                    "desired_state": {
+                                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "boot_artifacts": {
+                                                                "description": "A collection of boot artifacts.\n",
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "kernel": {
+                                                                        "type": "string",
+                                                                        "description": "An md5sum hash of the kernel ID"
+                                                                    },
+                                                                    "kernel_parameters": {
+                                                                        "type": "string",
+                                                                        "description": "Kernel parameters"
+                                                                    },
+                                                                    "initrd": {
+                                                                        "type": "string",
+                                                                        "description": "Initrd ID"
+                                                                    }
+                                                                },
+                                                                "additionalProperties": false
+                                                            },
+                                                            "configuration": {
+                                                                "type": "string",
+                                                                "description": "A CFS configuration ID."
+                                                            },
+                                                            "bss_token": {
+                                                                "type": "string",
+                                                                "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                            },
+                                                            "last_updated": {
+                                                                "type": "string",
+                                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                                "example": "2019-07-28T03:26:00Z",
+                                                                "format": "date-time",
+                                                                "readOnly": true
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "staged_state": {
+                                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "boot_artifacts": {
+                                                                "description": "A collection of boot artifacts.\n",
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "kernel": {
+                                                                        "type": "string",
+                                                                        "description": "An md5sum hash of the kernel ID"
+                                                                    },
+                                                                    "kernel_parameters": {
+                                                                        "type": "string",
+                                                                        "description": "Kernel parameters"
+                                                                    },
+                                                                    "initrd": {
+                                                                        "type": "string",
+                                                                        "description": "Initrd ID"
+                                                                    }
+                                                                },
+                                                                "additionalProperties": false
+                                                            },
+                                                            "configuration": {
+                                                                "type": "string",
+                                                                "description": "A CFS configuration ID."
+                                                            },
+                                                            "session": {
+                                                                "type": "string",
+                                                                "description": "A session which can be triggered at a later time against this component."
+                                                            },
+                                                            "last_updated": {
+                                                                "type": "string",
+                                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                                "example": "2019-07-28T03:26:00Z",
+                                                                "format": "date-time",
+                                                                "readOnly": true
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "last_action": {
+                                                        "description": "Information on the most recent action taken against the node.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "last_updated": {
+                                                                "type": "string",
+                                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                                "example": "2019-07-28T03:26:00Z",
+                                                                "format": "date-time",
+                                                                "readOnly": true
+                                                            },
+                                                            "action": {
+                                                                "type": "string",
+                                                                "description": "A description of the most recent operator/action to impact the component."
+                                                            },
+                                                            "num_attempts": {
+                                                                "type": "integer",
+                                                                "description": "How many attempts have been made for this action."
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "status": {
+                                                        "description": "Status information for the component",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "phase": {
+                                                                "type": "string",
+                                                                "description": "The current phase of the component in the boot process."
+                                                            },
+                                                            "status": {
+                                                                "type": "string",
+                                                                "description": "The current status of the component.  More detailed than phase.",
+                                                                "readOnly": true
+                                                            },
+                                                            "status_override": {
+                                                                "type": "string",
+                                                                "description": "If set, this will override the status value."
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "enabled": {
+                                                        "type": "boolean",
+                                                        "description": "A flag indicating if actions should be taken for this component."
+                                                    },
+                                                    "error": {
+                                                        "type": "string",
+                                                        "description": "A description of the most recent error to impact the component."
+                                                    },
+                                                    "session": {
+                                                        "type": "string",
+                                                        "description": "The session responsible for the component's current state"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "filters": {
+                                                "description": "Information for patching multiple components.",
+                                                "type": "object",
+                                                "properties": {
+                                                    "ids": {
+                                                        "type": "string",
+                                                        "description": "A comma separated list of component ids"
+                                                    },
+                                                    "session": {
+                                                        "type": "string",
+                                                        "description": "A session name.  All components part of this session will be patched."
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "patch",
+                                            "filters"
+                                        ]
+                                    },
+                                    {
+                                        "description": "An array of component states.",
+                                        "type": "array",
+                                        "items": {
+                                            "description": "The current and desired artifacts state for a component.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string",
+                                                    "description": "The component's id. e.g. xname for hardware components"
+                                                },
+                                                "actual_state": {
+                                                    "description": "The desired boot artifacts and configuration for a component\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "boot_artifacts": {
+                                                            "description": "A collection of boot artifacts.\n",
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "kernel": {
+                                                                    "type": "string",
+                                                                    "description": "An md5sum hash of the kernel ID"
+                                                                },
+                                                                "kernel_parameters": {
+                                                                    "type": "string",
+                                                                    "description": "Kernel parameters"
+                                                                },
+                                                                "initrd": {
+                                                                    "type": "string",
+                                                                    "description": "Initrd ID"
+                                                                }
+                                                            },
+                                                            "additionalProperties": false
+                                                        },
+                                                        "bss_token": {
+                                                            "type": "string",
+                                                            "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                        },
+                                                        "last_updated": {
+                                                            "type": "string",
+                                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                            "example": "2019-07-28T03:26:00Z",
+                                                            "format": "date-time",
+                                                            "readOnly": true
+                                                        }
+                                                    }
+                                                },
+                                                "desired_state": {
+                                                    "description": "The desired boot artifacts and configuration for a component\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "boot_artifacts": {
+                                                            "description": "A collection of boot artifacts.\n",
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "kernel": {
+                                                                    "type": "string",
+                                                                    "description": "An md5sum hash of the kernel ID"
+                                                                },
+                                                                "kernel_parameters": {
+                                                                    "type": "string",
+                                                                    "description": "Kernel parameters"
+                                                                },
+                                                                "initrd": {
+                                                                    "type": "string",
+                                                                    "description": "Initrd ID"
+                                                                }
+                                                            },
+                                                            "additionalProperties": false
+                                                        },
+                                                        "configuration": {
+                                                            "type": "string",
+                                                            "description": "A CFS configuration ID."
+                                                        },
+                                                        "bss_token": {
+                                                            "type": "string",
+                                                            "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                        },
+                                                        "last_updated": {
+                                                            "type": "string",
+                                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                            "example": "2019-07-28T03:26:00Z",
+                                                            "format": "date-time",
+                                                            "readOnly": true
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "staged_state": {
+                                                    "description": "The desired boot artifacts and configuration for a component\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "boot_artifacts": {
+                                                            "description": "A collection of boot artifacts.\n",
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "kernel": {
+                                                                    "type": "string",
+                                                                    "description": "An md5sum hash of the kernel ID"
+                                                                },
+                                                                "kernel_parameters": {
+                                                                    "type": "string",
+                                                                    "description": "Kernel parameters"
+                                                                },
+                                                                "initrd": {
+                                                                    "type": "string",
+                                                                    "description": "Initrd ID"
+                                                                }
+                                                            },
+                                                            "additionalProperties": false
+                                                        },
+                                                        "configuration": {
+                                                            "type": "string",
+                                                            "description": "A CFS configuration ID."
+                                                        },
+                                                        "session": {
+                                                            "type": "string",
+                                                            "description": "A session which can be triggered at a later time against this component."
+                                                        },
+                                                        "last_updated": {
+                                                            "type": "string",
+                                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                            "example": "2019-07-28T03:26:00Z",
+                                                            "format": "date-time",
+                                                            "readOnly": true
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "last_action": {
+                                                    "description": "Information on the most recent action taken against the node.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "last_updated": {
+                                                            "type": "string",
+                                                            "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                            "example": "2019-07-28T03:26:00Z",
+                                                            "format": "date-time",
+                                                            "readOnly": true
+                                                        },
+                                                        "action": {
+                                                            "type": "string",
+                                                            "description": "A description of the most recent operator/action to impact the component."
+                                                        },
+                                                        "num_attempts": {
+                                                            "type": "integer",
+                                                            "description": "How many attempts have been made for this action."
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "status": {
+                                                    "description": "Status information for the component",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "phase": {
+                                                            "type": "string",
+                                                            "description": "The current phase of the component in the boot process."
+                                                        },
+                                                        "status": {
+                                                            "type": "string",
+                                                            "description": "The current status of the component.  More detailed than phase.",
+                                                            "readOnly": true
+                                                        },
+                                                        "status_override": {
+                                                            "type": "string",
+                                                            "description": "If set, this will override the status value."
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "enabled": {
+                                                    "type": "boolean",
+                                                    "description": "A flag indicating if actions should be taken for this component."
+                                                },
+                                                "error": {
+                                                    "type": "string",
+                                                    "description": "A description of the most recent error to impact the component."
+                                                },
+                                                "session": {
+                                                    "type": "string",
+                                                    "description": "The session responsible for the component's current state"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "A collection of component states",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An array of component states.",
+                                    "type": "array",
+                                    "items": {
+                                        "description": "The current and desired artifacts state for a component.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "description": "The component's id. e.g. xname for hardware components"
+                                            },
+                                            "actual_state": {
+                                                "description": "The desired boot artifacts and configuration for a component\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "boot_artifacts": {
+                                                        "description": "A collection of boot artifacts.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kernel": {
+                                                                "type": "string",
+                                                                "description": "An md5sum hash of the kernel ID"
+                                                            },
+                                                            "kernel_parameters": {
+                                                                "type": "string",
+                                                                "description": "Kernel parameters"
+                                                            },
+                                                            "initrd": {
+                                                                "type": "string",
+                                                                "description": "Initrd ID"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "bss_token": {
+                                                        "type": "string",
+                                                        "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                    },
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    }
+                                                }
+                                            },
+                                            "desired_state": {
+                                                "description": "The desired boot artifacts and configuration for a component\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "boot_artifacts": {
+                                                        "description": "A collection of boot artifacts.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kernel": {
+                                                                "type": "string",
+                                                                "description": "An md5sum hash of the kernel ID"
+                                                            },
+                                                            "kernel_parameters": {
+                                                                "type": "string",
+                                                                "description": "Kernel parameters"
+                                                            },
+                                                            "initrd": {
+                                                                "type": "string",
+                                                                "description": "Initrd ID"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "configuration": {
+                                                        "type": "string",
+                                                        "description": "A CFS configuration ID."
+                                                    },
+                                                    "bss_token": {
+                                                        "type": "string",
+                                                        "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                    },
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "staged_state": {
+                                                "description": "The desired boot artifacts and configuration for a component\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "boot_artifacts": {
+                                                        "description": "A collection of boot artifacts.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "kernel": {
+                                                                "type": "string",
+                                                                "description": "An md5sum hash of the kernel ID"
+                                                            },
+                                                            "kernel_parameters": {
+                                                                "type": "string",
+                                                                "description": "Kernel parameters"
+                                                            },
+                                                            "initrd": {
+                                                                "type": "string",
+                                                                "description": "Initrd ID"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "configuration": {
+                                                        "type": "string",
+                                                        "description": "A CFS configuration ID."
+                                                    },
+                                                    "session": {
+                                                        "type": "string",
+                                                        "description": "A session which can be triggered at a later time against this component."
+                                                    },
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "last_action": {
+                                                "description": "Information on the most recent action taken against the node.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "last_updated": {
+                                                        "type": "string",
+                                                        "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                        "example": "2019-07-28T03:26:00Z",
+                                                        "format": "date-time",
+                                                        "readOnly": true
+                                                    },
+                                                    "action": {
+                                                        "type": "string",
+                                                        "description": "A description of the most recent operator/action to impact the component."
+                                                    },
+                                                    "num_attempts": {
+                                                        "type": "integer",
+                                                        "description": "How many attempts have been made for this action."
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "status": {
+                                                "description": "Status information for the component",
+                                                "type": "object",
+                                                "properties": {
+                                                    "phase": {
+                                                        "type": "string",
+                                                        "description": "The current phase of the component in the boot process."
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "description": "The current status of the component.  More detailed than phase.",
+                                                        "readOnly": true
+                                                    },
+                                                    "status_override": {
+                                                        "type": "string",
+                                                        "description": "If set, this will override the status value."
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "enabled": {
+                                                "type": "boolean",
+                                                "description": "A flag indicating if actions should be taken for this component."
+                                            },
+                                            "error": {
+                                                "type": "string",
+                                                "description": "A description of the most recent error to impact the component."
+                                            },
+                                            "session": {
+                                                "type": "string",
+                                                "description": "The session responsible for the component's current state"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The resource was not found.",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/components/{component_id}": {
+            "get": {
+                "summary": "Retrieve the state of a single component",
+                "tags": [
+                    "v2",
+                    "components"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.components",
+                "description": "Retrieve the current and desired state of a single component",
+                "operationId": "get_v2_component",
+                "responses": {
+                    "200": {
+                        "description": "A single component state",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "The current and desired artifacts state for a component.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": "The component's id. e.g. xname for hardware components"
+                                        },
+                                        "actual_state": {
+                                            "description": "The desired boot artifacts and configuration for a component\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "boot_artifacts": {
+                                                    "description": "A collection of boot artifacts.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "kernel": {
+                                                            "type": "string",
+                                                            "description": "An md5sum hash of the kernel ID"
+                                                        },
+                                                        "kernel_parameters": {
+                                                            "type": "string",
+                                                            "description": "Kernel parameters"
+                                                        },
+                                                        "initrd": {
+                                                            "type": "string",
+                                                            "description": "Initrd ID"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "bss_token": {
+                                                    "type": "string",
+                                                    "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                },
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                }
+                                            }
+                                        },
+                                        "desired_state": {
+                                            "description": "The desired boot artifacts and configuration for a component\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "boot_artifacts": {
+                                                    "description": "A collection of boot artifacts.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "kernel": {
+                                                            "type": "string",
+                                                            "description": "An md5sum hash of the kernel ID"
+                                                        },
+                                                        "kernel_parameters": {
+                                                            "type": "string",
+                                                            "description": "Kernel parameters"
+                                                        },
+                                                        "initrd": {
+                                                            "type": "string",
+                                                            "description": "Initrd ID"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "configuration": {
+                                                    "type": "string",
+                                                    "description": "A CFS configuration ID."
+                                                },
+                                                "bss_token": {
+                                                    "type": "string",
+                                                    "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                },
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "staged_state": {
+                                            "description": "The desired boot artifacts and configuration for a component\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "boot_artifacts": {
+                                                    "description": "A collection of boot artifacts.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "kernel": {
+                                                            "type": "string",
+                                                            "description": "An md5sum hash of the kernel ID"
+                                                        },
+                                                        "kernel_parameters": {
+                                                            "type": "string",
+                                                            "description": "Kernel parameters"
+                                                        },
+                                                        "initrd": {
+                                                            "type": "string",
+                                                            "description": "Initrd ID"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "configuration": {
+                                                    "type": "string",
+                                                    "description": "A CFS configuration ID."
+                                                },
+                                                "session": {
+                                                    "type": "string",
+                                                    "description": "A session which can be triggered at a later time against this component."
+                                                },
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "last_action": {
+                                            "description": "Information on the most recent action taken against the node.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                },
+                                                "action": {
+                                                    "type": "string",
+                                                    "description": "A description of the most recent operator/action to impact the component."
+                                                },
+                                                "num_attempts": {
+                                                    "type": "integer",
+                                                    "description": "How many attempts have been made for this action."
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "status": {
+                                            "description": "Status information for the component",
+                                            "type": "object",
+                                            "properties": {
+                                                "phase": {
+                                                    "type": "string",
+                                                    "description": "The current phase of the component in the boot process."
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "The current status of the component.  More detailed than phase.",
+                                                    "readOnly": true
+                                                },
+                                                "status_override": {
+                                                    "type": "string",
+                                                    "description": "If set, this will override the status value."
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "description": "A flag indicating if actions should be taken for this component."
+                                        },
+                                        "error": {
+                                            "type": "string",
+                                            "description": "A description of the most recent error to impact the component."
+                                        },
+                                        "session": {
+                                            "type": "string",
+                                            "description": "The session responsible for the component's current state"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The resource was not found.",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "summary": "Add or Replace a single component",
+                "tags": [
+                    "v2",
+                    "components"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.components",
+                "description": "Update the state for a given component in the BOS database",
+                "operationId": "put_v2_component",
+                "requestBody": {
+                    "description": "The state for a single component",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "description": "The current and desired artifacts state for a component.\n",
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The component's id. e.g. xname for hardware components"
+                                    },
+                                    "actual_state": {
+                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "boot_artifacts": {
+                                                "description": "A collection of boot artifacts.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "kernel": {
+                                                        "type": "string",
+                                                        "description": "An md5sum hash of the kernel ID"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "Kernel parameters"
+                                                    },
+                                                    "initrd": {
+                                                        "type": "string",
+                                                        "description": "Initrd ID"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "bss_token": {
+                                                "type": "string",
+                                                "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                            },
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            }
+                                        }
+                                    },
+                                    "desired_state": {
+                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "boot_artifacts": {
+                                                "description": "A collection of boot artifacts.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "kernel": {
+                                                        "type": "string",
+                                                        "description": "An md5sum hash of the kernel ID"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "Kernel parameters"
+                                                    },
+                                                    "initrd": {
+                                                        "type": "string",
+                                                        "description": "Initrd ID"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "configuration": {
+                                                "type": "string",
+                                                "description": "A CFS configuration ID."
+                                            },
+                                            "bss_token": {
+                                                "type": "string",
+                                                "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                            },
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "staged_state": {
+                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "boot_artifacts": {
+                                                "description": "A collection of boot artifacts.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "kernel": {
+                                                        "type": "string",
+                                                        "description": "An md5sum hash of the kernel ID"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "Kernel parameters"
+                                                    },
+                                                    "initrd": {
+                                                        "type": "string",
+                                                        "description": "Initrd ID"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "configuration": {
+                                                "type": "string",
+                                                "description": "A CFS configuration ID."
+                                            },
+                                            "session": {
+                                                "type": "string",
+                                                "description": "A session which can be triggered at a later time against this component."
+                                            },
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "last_action": {
+                                        "description": "Information on the most recent action taken against the node.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            },
+                                            "action": {
+                                                "type": "string",
+                                                "description": "A description of the most recent operator/action to impact the component."
+                                            },
+                                            "num_attempts": {
+                                                "type": "integer",
+                                                "description": "How many attempts have been made for this action."
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "status": {
+                                        "description": "Status information for the component",
+                                        "type": "object",
+                                        "properties": {
+                                            "phase": {
+                                                "type": "string",
+                                                "description": "The current phase of the component in the boot process."
+                                            },
+                                            "status": {
+                                                "type": "string",
+                                                "description": "The current status of the component.  More detailed than phase.",
+                                                "readOnly": true
+                                            },
+                                            "status_override": {
+                                                "type": "string",
+                                                "description": "If set, this will override the status value."
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "enabled": {
+                                        "type": "boolean",
+                                        "description": "A flag indicating if actions should be taken for this component."
+                                    },
+                                    "error": {
+                                        "type": "string",
+                                        "description": "A description of the most recent error to impact the component."
+                                    },
+                                    "session": {
+                                        "type": "string",
+                                        "description": "The session responsible for the component's current state"
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "A single component state",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "The current and desired artifacts state for a component.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": "The component's id. e.g. xname for hardware components"
+                                        },
+                                        "actual_state": {
+                                            "description": "The desired boot artifacts and configuration for a component\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "boot_artifacts": {
+                                                    "description": "A collection of boot artifacts.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "kernel": {
+                                                            "type": "string",
+                                                            "description": "An md5sum hash of the kernel ID"
+                                                        },
+                                                        "kernel_parameters": {
+                                                            "type": "string",
+                                                            "description": "Kernel parameters"
+                                                        },
+                                                        "initrd": {
+                                                            "type": "string",
+                                                            "description": "Initrd ID"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "bss_token": {
+                                                    "type": "string",
+                                                    "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                },
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                }
+                                            }
+                                        },
+                                        "desired_state": {
+                                            "description": "The desired boot artifacts and configuration for a component\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "boot_artifacts": {
+                                                    "description": "A collection of boot artifacts.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "kernel": {
+                                                            "type": "string",
+                                                            "description": "An md5sum hash of the kernel ID"
+                                                        },
+                                                        "kernel_parameters": {
+                                                            "type": "string",
+                                                            "description": "Kernel parameters"
+                                                        },
+                                                        "initrd": {
+                                                            "type": "string",
+                                                            "description": "Initrd ID"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "configuration": {
+                                                    "type": "string",
+                                                    "description": "A CFS configuration ID."
+                                                },
+                                                "bss_token": {
+                                                    "type": "string",
+                                                    "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                },
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "staged_state": {
+                                            "description": "The desired boot artifacts and configuration for a component\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "boot_artifacts": {
+                                                    "description": "A collection of boot artifacts.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "kernel": {
+                                                            "type": "string",
+                                                            "description": "An md5sum hash of the kernel ID"
+                                                        },
+                                                        "kernel_parameters": {
+                                                            "type": "string",
+                                                            "description": "Kernel parameters"
+                                                        },
+                                                        "initrd": {
+                                                            "type": "string",
+                                                            "description": "Initrd ID"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "configuration": {
+                                                    "type": "string",
+                                                    "description": "A CFS configuration ID."
+                                                },
+                                                "session": {
+                                                    "type": "string",
+                                                    "description": "A session which can be triggered at a later time against this component."
+                                                },
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "last_action": {
+                                            "description": "Information on the most recent action taken against the node.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                },
+                                                "action": {
+                                                    "type": "string",
+                                                    "description": "A description of the most recent operator/action to impact the component."
+                                                },
+                                                "num_attempts": {
+                                                    "type": "integer",
+                                                    "description": "How many attempts have been made for this action."
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "status": {
+                                            "description": "Status information for the component",
+                                            "type": "object",
+                                            "properties": {
+                                                "phase": {
+                                                    "type": "string",
+                                                    "description": "The current phase of the component in the boot process."
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "The current status of the component.  More detailed than phase.",
+                                                    "readOnly": true
+                                                },
+                                                "status_override": {
+                                                    "type": "string",
+                                                    "description": "If set, this will override the status value."
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "description": "A flag indicating if actions should be taken for this component."
+                                        },
+                                        "error": {
+                                            "type": "string",
+                                            "description": "A description of the most recent error to impact the component."
+                                        },
+                                        "session": {
+                                            "type": "string",
+                                            "description": "The session responsible for the component's current state"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "summary": "Update a single component",
+                "tags": [
+                    "v2",
+                    "components"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.components",
+                "description": "Update the state for a given component in the BOS database",
+                "operationId": "patch_v2_component",
+                "requestBody": {
+                    "description": "The state for a single component",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "description": "The current and desired artifacts state for a component.\n",
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The component's id. e.g. xname for hardware components"
+                                    },
+                                    "actual_state": {
+                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "boot_artifacts": {
+                                                "description": "A collection of boot artifacts.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "kernel": {
+                                                        "type": "string",
+                                                        "description": "An md5sum hash of the kernel ID"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "Kernel parameters"
+                                                    },
+                                                    "initrd": {
+                                                        "type": "string",
+                                                        "description": "Initrd ID"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "bss_token": {
+                                                "type": "string",
+                                                "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                            },
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            }
+                                        }
+                                    },
+                                    "desired_state": {
+                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "boot_artifacts": {
+                                                "description": "A collection of boot artifacts.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "kernel": {
+                                                        "type": "string",
+                                                        "description": "An md5sum hash of the kernel ID"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "Kernel parameters"
+                                                    },
+                                                    "initrd": {
+                                                        "type": "string",
+                                                        "description": "Initrd ID"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "configuration": {
+                                                "type": "string",
+                                                "description": "A CFS configuration ID."
+                                            },
+                                            "bss_token": {
+                                                "type": "string",
+                                                "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                            },
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "staged_state": {
+                                        "description": "The desired boot artifacts and configuration for a component\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "boot_artifacts": {
+                                                "description": "A collection of boot artifacts.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "kernel": {
+                                                        "type": "string",
+                                                        "description": "An md5sum hash of the kernel ID"
+                                                    },
+                                                    "kernel_parameters": {
+                                                        "type": "string",
+                                                        "description": "Kernel parameters"
+                                                    },
+                                                    "initrd": {
+                                                        "type": "string",
+                                                        "description": "Initrd ID"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "configuration": {
+                                                "type": "string",
+                                                "description": "A CFS configuration ID."
+                                            },
+                                            "session": {
+                                                "type": "string",
+                                                "description": "A session which can be triggered at a later time against this component."
+                                            },
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "last_action": {
+                                        "description": "Information on the most recent action taken against the node.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "last_updated": {
+                                                "type": "string",
+                                                "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                "example": "2019-07-28T03:26:00Z",
+                                                "format": "date-time",
+                                                "readOnly": true
+                                            },
+                                            "action": {
+                                                "type": "string",
+                                                "description": "A description of the most recent operator/action to impact the component."
+                                            },
+                                            "num_attempts": {
+                                                "type": "integer",
+                                                "description": "How many attempts have been made for this action."
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "status": {
+                                        "description": "Status information for the component",
+                                        "type": "object",
+                                        "properties": {
+                                            "phase": {
+                                                "type": "string",
+                                                "description": "The current phase of the component in the boot process."
+                                            },
+                                            "status": {
+                                                "type": "string",
+                                                "description": "The current status of the component.  More detailed than phase.",
+                                                "readOnly": true
+                                            },
+                                            "status_override": {
+                                                "type": "string",
+                                                "description": "If set, this will override the status value."
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "enabled": {
+                                        "type": "boolean",
+                                        "description": "A flag indicating if actions should be taken for this component."
+                                    },
+                                    "error": {
+                                        "type": "string",
+                                        "description": "A description of the most recent error to impact the component."
+                                    },
+                                    "session": {
+                                        "type": "string",
+                                        "description": "The session responsible for the component's current state"
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "A single component state",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "The current and desired artifacts state for a component.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": "The component's id. e.g. xname for hardware components"
+                                        },
+                                        "actual_state": {
+                                            "description": "The desired boot artifacts and configuration for a component\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "boot_artifacts": {
+                                                    "description": "A collection of boot artifacts.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "kernel": {
+                                                            "type": "string",
+                                                            "description": "An md5sum hash of the kernel ID"
+                                                        },
+                                                        "kernel_parameters": {
+                                                            "type": "string",
+                                                            "description": "Kernel parameters"
+                                                        },
+                                                        "initrd": {
+                                                            "type": "string",
+                                                            "description": "Initrd ID"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "bss_token": {
+                                                    "type": "string",
+                                                    "description": "A token received from the node identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                },
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                }
+                                            }
+                                        },
+                                        "desired_state": {
+                                            "description": "The desired boot artifacts and configuration for a component\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "boot_artifacts": {
+                                                    "description": "A collection of boot artifacts.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "kernel": {
+                                                            "type": "string",
+                                                            "description": "An md5sum hash of the kernel ID"
+                                                        },
+                                                        "kernel_parameters": {
+                                                            "type": "string",
+                                                            "description": "Kernel parameters"
+                                                        },
+                                                        "initrd": {
+                                                            "type": "string",
+                                                            "description": "Initrd ID"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "configuration": {
+                                                    "type": "string",
+                                                    "description": "A CFS configuration ID."
+                                                },
+                                                "bss_token": {
+                                                    "type": "string",
+                                                    "description": "A token received from BSS identifying the boot artifacts.  For BOS use-only, users should not set this field. It will be overwritten.\n"
+                                                },
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "staged_state": {
+                                            "description": "The desired boot artifacts and configuration for a component\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "boot_artifacts": {
+                                                    "description": "A collection of boot artifacts.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "kernel": {
+                                                            "type": "string",
+                                                            "description": "An md5sum hash of the kernel ID"
+                                                        },
+                                                        "kernel_parameters": {
+                                                            "type": "string",
+                                                            "description": "Kernel parameters"
+                                                        },
+                                                        "initrd": {
+                                                            "type": "string",
+                                                            "description": "Initrd ID"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "configuration": {
+                                                    "type": "string",
+                                                    "description": "A CFS configuration ID."
+                                                },
+                                                "session": {
+                                                    "type": "string",
+                                                    "description": "A session which can be triggered at a later time against this component."
+                                                },
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "last_action": {
+                                            "description": "Information on the most recent action taken against the node.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "description": "The date/time when the state was last updated in RFC 3339 format.",
+                                                    "example": "2019-07-28T03:26:00Z",
+                                                    "format": "date-time",
+                                                    "readOnly": true
+                                                },
+                                                "action": {
+                                                    "type": "string",
+                                                    "description": "A description of the most recent operator/action to impact the component."
+                                                },
+                                                "num_attempts": {
+                                                    "type": "integer",
+                                                    "description": "How many attempts have been made for this action."
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "status": {
+                                            "description": "Status information for the component",
+                                            "type": "object",
+                                            "properties": {
+                                                "phase": {
+                                                    "type": "string",
+                                                    "description": "The current phase of the component in the boot process."
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "The current status of the component.  More detailed than phase.",
+                                                    "readOnly": true
+                                                },
+                                                "status_override": {
+                                                    "type": "string",
+                                                    "description": "If set, this will override the status value."
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "description": "A flag indicating if actions should be taken for this component."
+                                        },
+                                        "error": {
+                                            "type": "string",
+                                            "description": "A description of the most recent error to impact the component."
+                                        },
+                                        "session": {
+                                            "type": "string",
+                                            "description": "The session responsible for the component's current state"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The resource was not found.",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "v2",
+                    "components",
+                    "cli_ignore"
+                ],
+                "summary": "Delete a single component",
+                "x-openapi-router-controller": "bos.server.controllers.v2.components",
+                "description": "Delete the given component",
+                "operationId": "delete_v2_component",
+                "responses": {
+                    "204": {
+                        "description": "The resource was deleted."
+                    },
+                    "404": {
+                        "description": "The resource was not found.",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "component_id",
+                    "in": "path",
+                    "description": "Component id. e.g. xname for hardware components",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "/v2/applystaged": {
+            "post": {
+                "summary": "Start a staged session for the specified components",
+                "description": "Given a list of xnames, this will trigger the start of any sessions\nstaged for those components.  Components without a staged session\nwill be ignored, and a list all components that are acted on will\nbe returned in the response.\n",
+                "tags": [
+                    "v2",
+                    "applystaged"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.components",
+                "operationId": "post_v2_apply_staged",
+                "requestBody": {
+                    "description": "A list of xnames that should have their staged session applied.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "description": "A list of components that should have their staged session applied.\n",
+                                "type": "object",
+                                "properties": {
+                                    "xnames": {
+                                        "description": "The list of component xnames",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "A list of xnames that should have their staged session applied.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "A list of components that should have their staged session applied.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "succeeded": {
+                                            "description": "The list of component xnames",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "failed": {
+                                            "description": "The list of component xnames",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "ignored": {
+                                            "description": "The list of component xnames",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/options": {
+            "get": {
+                "summary": "Retrieve the BOS service options",
+                "tags": [
+                    "options"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.options",
+                "description": "Retrieve the list of BOS service options.",
+                "operationId": "get_v2_options",
+                "responses": {
+                    "200": {
+                        "description": "A collection of service-wide options",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "Options for the boot orchestration service.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "cleanup_completed_session_ttl": {
+                                            "type": "string",
+                                            "description": "Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior."
+                                        },
+                                        "component_actual_state_ttl": {
+                                            "type": "string",
+                                            "description": "The maximum amount of time a component's actual state is considered valid (in hours). 0h disables cleanup behavior for newly booted nodes and instructs bos-state-reporter to report once instead of periodically."
+                                        },
+                                        "disable_components_on_completion": {
+                                            "type": "boolean",
+                                            "description": "Allows for BOS components to be marked as disabled after a session has been completed. If false, BOS will continue to maintain the state of the nodes declaratively, even after a session finishes."
+                                        },
+                                        "discovery_frequency": {
+                                            "type": "integer",
+                                            "description": "How frequently the BOS discovery agent syncs new components from HSM. (in seconds)"
+                                        },
+                                        "logging_level": {
+                                            "type": "string",
+                                            "description": "The logging level for all BOS services"
+                                        },
+                                        "max_power_on_wait_time": {
+                                            "type": "integer",
+                                            "description": "How long BOS will wait for a node to power on before rebooting again (in seconds)"
+                                        },
+                                        "max_power_off_wait_time": {
+                                            "type": "integer",
+                                            "description": "How long BOS will wait for a node to power off before forcefully powering off (in seconds)"
+                                        },
+                                        "polling_frequency": {
+                                            "type": "integer",
+                                            "description": "How frequently the BOS operators check component state for needed actions. (in seconds)"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "summary": "Update BOS service options",
+                "tags": [
+                    "v2",
+                    "options"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.options",
+                "operationId": "patch_v2_options",
+                "description": "Update one or more of the BOS service options.",
+                "requestBody": {
+                    "description": "Service-wide options",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "description": "Options for the boot orchestration service.\n",
+                                "type": "object",
+                                "properties": {
+                                    "cleanup_completed_session_ttl": {
+                                        "type": "string",
+                                        "description": "Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior."
+                                    },
+                                    "component_actual_state_ttl": {
+                                        "type": "string",
+                                        "description": "The maximum amount of time a component's actual state is considered valid (in hours). 0h disables cleanup behavior for newly booted nodes and instructs bos-state-reporter to report once instead of periodically."
+                                    },
+                                    "disable_components_on_completion": {
+                                        "type": "boolean",
+                                        "description": "Allows for BOS components to be marked as disabled after a session has been completed. If false, BOS will continue to maintain the state of the nodes declaratively, even after a session finishes."
+                                    },
+                                    "discovery_frequency": {
+                                        "type": "integer",
+                                        "description": "How frequently the BOS discovery agent syncs new components from HSM. (in seconds)"
+                                    },
+                                    "logging_level": {
+                                        "type": "string",
+                                        "description": "The logging level for all BOS services"
+                                    },
+                                    "max_power_on_wait_time": {
+                                        "type": "integer",
+                                        "description": "How long BOS will wait for a node to power on before rebooting again (in seconds)"
+                                    },
+                                    "max_power_off_wait_time": {
+                                        "type": "integer",
+                                        "description": "How long BOS will wait for a node to power off before forcefully powering off (in seconds)"
+                                    },
+                                    "polling_frequency": {
+                                        "type": "integer",
+                                        "description": "How frequently the BOS operators check component state for needed actions. (in seconds)"
+                                    }
+                                },
+                                "additionalProperties": true
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "A collection of service-wide options",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "Options for the boot orchestration service.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "cleanup_completed_session_ttl": {
+                                            "type": "string",
+                                            "description": "Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior."
+                                        },
+                                        "component_actual_state_ttl": {
+                                            "type": "string",
+                                            "description": "The maximum amount of time a component's actual state is considered valid (in hours). 0h disables cleanup behavior for newly booted nodes and instructs bos-state-reporter to report once instead of periodically."
+                                        },
+                                        "disable_components_on_completion": {
+                                            "type": "boolean",
+                                            "description": "Allows for BOS components to be marked as disabled after a session has been completed. If false, BOS will continue to maintain the state of the nodes declaratively, even after a session finishes."
+                                        },
+                                        "discovery_frequency": {
+                                            "type": "integer",
+                                            "description": "How frequently the BOS discovery agent syncs new components from HSM. (in seconds)"
+                                        },
+                                        "logging_level": {
+                                            "type": "string",
+                                            "description": "The logging level for all BOS services"
+                                        },
+                                        "max_power_on_wait_time": {
+                                            "type": "integer",
+                                            "description": "How long BOS will wait for a node to power on before rebooting again (in seconds)"
+                                        },
+                                        "max_power_off_wait_time": {
+                                            "type": "integer",
+                                            "description": "How long BOS will wait for a node to power off before forcefully powering off (in seconds)"
+                                        },
+                                        "polling_frequency": {
+                                            "type": "integer",
+                                            "description": "How frequently the BOS operators check component state for needed actions. (in seconds)"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human readable documentation.",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/version": {
+            "get": {
+                "summary": "Get API version",
+                "tags": [
+                    "v2",
+                    "version"
+                ],
+                "x-openapi-router-controller": "bos.server.controllers.v2.base",
+                "operationId": "get_version_v2",
+                "responses": {
+                    "200": {
+                        "description": "Get version details\nThe versioning system uses [semver](https://semver.org/).\n## Link Relationships\n* self : Link to itself\n* versions : Link back to the versions resource\n",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "Version data",
+                                    "type": "object",
+                                    "properties": {
+                                        "major": {
+                                            "type": "integer"
+                                        },
+                                        "minor": {
+                                            "type": "integer"
+                                        },
+                                        "patch": {
+                                            "type": "integer"
+                                        },
+                                        "links": {
+                                            "type": "array",
+                                            "items": {
+                                                "description": "Link to other resources",
+                                                "type": "object",
+                                                "properties": {
+                                                    "rel": {
+                                                        "type": "string"
+                                                    },
+                                                    "href": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            }
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Bad Request",
                         "content": {
                             "application/problem+json": {
                                 "schema": {

--- a/tests/test_modules/test_bos.py
+++ b/tests/test_modules/test_bos.py
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 """ Test the bos module.
 
 MIT License
@@ -178,7 +201,6 @@ def test_cray_bos_sessiontemplate_create_full(cli_runner, rest_mock):
                                  '--enable-cfs', True,
                                  '--cfs-configuration', 'test-config',
                                  '--description', 'desc',
-                                 '--template-body', 'test-body',
                                  '--template-url', 'test-url'])
     assert result.exit_code == 0
     data = json.loads(result.output)
@@ -192,7 +214,6 @@ def test_cray_bos_sessiontemplate_create_full(cli_runner, rest_mock):
         'enable_cfs': True,
         'cfs': {'configuration': 'test-config'},
         'description': 'desc',
-        'templateBody': 'test-body',
         'templateUrl': 'test-url',
     }
     compare_dicts(expected, data['body'])


### PR DESCRIPTION
## Summary and Scope

This adds the BOS v2 api to the cli.  It also adds a new way to inject code into the generator so that it's possible to access data at a point that is not otherwise possible.  This is necessary in order to setup a new bulk update endpoint for the cli.

## Issues and Related PRs

* Resolves CASMCMS-7876

## Testing

### Tested on:

  * Hela and others

### Test description:

We have been using this to call all the commands while testing BOS v2

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

