### PR TITLE
CASMCMS-7876: Update BOS cli for retry limits in v2

### DIFF
--- a/cray/modules/bos/openapi.yaml
+++ b/cray/modules/bos/openapi.yaml
@@ -1,3 +1,4 @@
+
 #
 # MIT License
 #
@@ -1068,9 +1069,21 @@ components:
         action:
           type: string
           description: A description of the most recent operator/action to impact the component.
-        num_attempts:
+      additionalProperties: false
+    V2ComponentEventStats:
+      description: |
+        Information on the most recent attempt to return the node to its desired state.
+      type: object
+      properties:
+        power_on_attempts:
           type: integer
-          description: How many attempts have been made for this action.
+          description: How many attempts have been made to power-on since the last time the node was in the desired state.
+        power_off_graceful_attempts:
+          type: integer
+          description: How many attempts have been made to power-off gracefully since the last time the node was in the desired state.
+        power_off_forceful_attempts:
+          type: integer
+          description: How many attempts have been made to power-off forcefully since the last time the node was in the desired state.
       additionalProperties: false
     V2ComponentStatus:
       description: Status information for the component
@@ -1103,6 +1116,8 @@ components:
           $ref: '#/components/schemas/V2ComponentStagedState'
         last_action:
           $ref: '#/components/schemas/V2ComponentLastAction'
+        event_stats:
+          $ref: '#/components/schemas/V2ComponentEventStats'
         status:
           $ref: '#/components/schemas/V2ComponentStatus'
         enabled:
@@ -1114,6 +1129,12 @@ components:
         session:
           type: string
           description: The session responsible for the component's current state
+        retry_policy:
+          type: integer
+          description: |
+            The maximum number attempts per action when actions fail.
+            Defaults to the global default_retry_policy if not set
+          example: 1
       additionalProperties: false
     V2ComponentArray:
       description: An array of component states.
@@ -1200,6 +1221,10 @@ components:
         polling_frequency:
           type: integer
           description: How frequently the BOS operators check component state for needed actions. (in seconds)
+        default_retry_policy:
+          type: integer
+          description: The default maximum number attempts per node for failed actions.
+          example: 1
       additionalProperties: true
   requestBodies:
     V2sessionCreateRequest:

--- a/cray/modules/bos/swagger3.json
+++ b/cray/modules/bos/swagger3.json
@@ -1816,10 +1816,25 @@
                     "action": {
                         "type": "string",
                         "description": "A description of the most recent operator/action to impact the component."
-                    },
-                    "num_attempts": {
+                    }
+                },
+                "additionalProperties": false
+            },
+            "V2ComponentEventStats": {
+                "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                "type": "object",
+                "properties": {
+                    "power_on_attempts": {
                         "type": "integer",
-                        "description": "How many attempts have been made for this action."
+                        "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                    },
+                    "power_off_graceful_attempts": {
+                        "type": "integer",
+                        "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                    },
+                    "power_off_forceful_attempts": {
+                        "type": "integer",
+                        "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                     }
                 },
                 "additionalProperties": false
@@ -1984,10 +1999,25 @@
                             "action": {
                                 "type": "string",
                                 "description": "A description of the most recent operator/action to impact the component."
-                            },
-                            "num_attempts": {
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "event_stats": {
+                        "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                        "type": "object",
+                        "properties": {
+                            "power_on_attempts": {
                                 "type": "integer",
-                                "description": "How many attempts have been made for this action."
+                                "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                            },
+                            "power_off_graceful_attempts": {
+                                "type": "integer",
+                                "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                            },
+                            "power_off_forceful_attempts": {
+                                "type": "integer",
+                                "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                             }
                         },
                         "additionalProperties": false
@@ -2023,6 +2053,11 @@
                     "session": {
                         "type": "string",
                         "description": "The session responsible for the component's current state"
+                    },
+                    "retry_policy": {
+                        "type": "integer",
+                        "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                        "example": 1
                     }
                 },
                 "additionalProperties": false
@@ -2170,10 +2205,25 @@
                                 "action": {
                                     "type": "string",
                                     "description": "A description of the most recent operator/action to impact the component."
-                                },
-                                "num_attempts": {
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "event_stats": {
+                            "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                            "type": "object",
+                            "properties": {
+                                "power_on_attempts": {
                                     "type": "integer",
-                                    "description": "How many attempts have been made for this action."
+                                    "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                },
+                                "power_off_graceful_attempts": {
+                                    "type": "integer",
+                                    "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                },
+                                "power_off_forceful_attempts": {
+                                    "type": "integer",
+                                    "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                 }
                             },
                             "additionalProperties": false
@@ -2209,6 +2259,11 @@
                         "session": {
                             "type": "string",
                             "description": "The session responsible for the component's current state"
+                        },
+                        "retry_policy": {
+                            "type": "integer",
+                            "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                            "example": 1
                         }
                     },
                     "additionalProperties": false
@@ -2372,10 +2427,25 @@
                                     "action": {
                                         "type": "string",
                                         "description": "A description of the most recent operator/action to impact the component."
-                                    },
-                                    "num_attempts": {
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "event_stats": {
+                                "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                "type": "object",
+                                "properties": {
+                                    "power_on_attempts": {
                                         "type": "integer",
-                                        "description": "How many attempts have been made for this action."
+                                        "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                    },
+                                    "power_off_graceful_attempts": {
+                                        "type": "integer",
+                                        "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                    },
+                                    "power_off_forceful_attempts": {
+                                        "type": "integer",
+                                        "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                     }
                                 },
                                 "additionalProperties": false
@@ -2411,6 +2481,11 @@
                             "session": {
                                 "type": "string",
                                 "description": "The session responsible for the component's current state"
+                            },
+                            "retry_policy": {
+                                "type": "integer",
+                                "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                "example": 1
                             }
                         },
                         "additionalProperties": false
@@ -2512,6 +2587,11 @@
                     "polling_frequency": {
                         "type": "integer",
                         "description": "How frequently the BOS operators check component state for needed actions. (in seconds)"
+                    },
+                    "default_retry_policy": {
+                        "type": "integer",
+                        "description": "The default maximum number attempts per node for failed actions.",
+                        "example": 1
                     }
                 },
                 "additionalProperties": true
@@ -2714,10 +2794,25 @@
                                         "action": {
                                             "type": "string",
                                             "description": "A description of the most recent operator/action to impact the component."
-                                        },
-                                        "num_attempts": {
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "event_stats": {
+                                    "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "power_on_attempts": {
                                             "type": "integer",
-                                            "description": "How many attempts have been made for this action."
+                                            "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                        },
+                                        "power_off_graceful_attempts": {
+                                            "type": "integer",
+                                            "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                        },
+                                        "power_off_forceful_attempts": {
+                                            "type": "integer",
+                                            "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                         }
                                     },
                                     "additionalProperties": false
@@ -2753,6 +2848,11 @@
                                 "session": {
                                     "type": "string",
                                     "description": "The session responsible for the component's current state"
+                                },
+                                "retry_policy": {
+                                    "type": "integer",
+                                    "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                    "example": 1
                                 }
                             },
                             "additionalProperties": false
@@ -2908,10 +3008,25 @@
                                             "action": {
                                                 "type": "string",
                                                 "description": "A description of the most recent operator/action to impact the component."
-                                            },
-                                            "num_attempts": {
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "event_stats": {
+                                        "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "power_on_attempts": {
                                                 "type": "integer",
-                                                "description": "How many attempts have been made for this action."
+                                                "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                            },
+                                            "power_off_graceful_attempts": {
+                                                "type": "integer",
+                                                "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                            },
+                                            "power_off_forceful_attempts": {
+                                                "type": "integer",
+                                                "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                             }
                                         },
                                         "additionalProperties": false
@@ -2947,6 +3062,11 @@
                                     "session": {
                                         "type": "string",
                                         "description": "The session responsible for the component's current state"
+                                    },
+                                    "retry_policy": {
+                                        "type": "integer",
+                                        "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                        "example": 1
                                     }
                                 },
                                 "additionalProperties": false
@@ -3106,10 +3226,25 @@
                                                         "action": {
                                                             "type": "string",
                                                             "description": "A description of the most recent operator/action to impact the component."
-                                                        },
-                                                        "num_attempts": {
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "event_stats": {
+                                                    "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "power_on_attempts": {
                                                             "type": "integer",
-                                                            "description": "How many attempts have been made for this action."
+                                                            "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                                        },
+                                                        "power_off_graceful_attempts": {
+                                                            "type": "integer",
+                                                            "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                                        },
+                                                        "power_off_forceful_attempts": {
+                                                            "type": "integer",
+                                                            "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                                         }
                                                     },
                                                     "additionalProperties": false
@@ -3145,6 +3280,11 @@
                                                 "session": {
                                                     "type": "string",
                                                     "description": "The session responsible for the component's current state"
+                                                },
+                                                "retry_policy": {
+                                                    "type": "integer",
+                                                    "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                                    "example": 1
                                                 }
                                             },
                                             "additionalProperties": false
@@ -3312,10 +3452,25 @@
                                                     "action": {
                                                         "type": "string",
                                                         "description": "A description of the most recent operator/action to impact the component."
-                                                    },
-                                                    "num_attempts": {
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "event_stats": {
+                                                "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "power_on_attempts": {
                                                         "type": "integer",
-                                                        "description": "How many attempts have been made for this action."
+                                                        "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                                    },
+                                                    "power_off_graceful_attempts": {
+                                                        "type": "integer",
+                                                        "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                                    },
+                                                    "power_off_forceful_attempts": {
+                                                        "type": "integer",
+                                                        "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                                     }
                                                 },
                                                 "additionalProperties": false
@@ -3351,6 +3506,11 @@
                                             "session": {
                                                 "type": "string",
                                                 "description": "The session responsible for the component's current state"
+                                            },
+                                            "retry_policy": {
+                                                "type": "integer",
+                                                "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                                "example": 1
                                             }
                                         },
                                         "additionalProperties": false
@@ -3401,6 +3561,11 @@
                                 "polling_frequency": {
                                     "type": "integer",
                                     "description": "How frequently the BOS operators check component state for needed actions. (in seconds)"
+                                },
+                                "default_retry_policy": {
+                                    "type": "integer",
+                                    "description": "The default maximum number attempts per node for failed actions.",
+                                    "example": 1
                                 }
                             },
                             "additionalProperties": true
@@ -4547,10 +4712,25 @@
                                         "action": {
                                             "type": "string",
                                             "description": "A description of the most recent operator/action to impact the component."
-                                        },
-                                        "num_attempts": {
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "event_stats": {
+                                    "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                    "type": "object",
+                                    "properties": {
+                                        "power_on_attempts": {
                                             "type": "integer",
-                                            "description": "How many attempts have been made for this action."
+                                            "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                        },
+                                        "power_off_graceful_attempts": {
+                                            "type": "integer",
+                                            "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                        },
+                                        "power_off_forceful_attempts": {
+                                            "type": "integer",
+                                            "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                         }
                                     },
                                     "additionalProperties": false
@@ -4586,6 +4766,11 @@
                                 "session": {
                                     "type": "string",
                                     "description": "The session responsible for the component's current state"
+                                },
+                                "retry_policy": {
+                                    "type": "integer",
+                                    "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                    "example": 1
                                 }
                             },
                             "additionalProperties": false
@@ -4740,10 +4925,25 @@
                                             "action": {
                                                 "type": "string",
                                                 "description": "A description of the most recent operator/action to impact the component."
-                                            },
-                                            "num_attempts": {
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "event_stats": {
+                                        "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "power_on_attempts": {
                                                 "type": "integer",
-                                                "description": "How many attempts have been made for this action."
+                                                "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                            },
+                                            "power_off_graceful_attempts": {
+                                                "type": "integer",
+                                                "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                            },
+                                            "power_off_forceful_attempts": {
+                                                "type": "integer",
+                                                "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                             }
                                         },
                                         "additionalProperties": false
@@ -4779,6 +4979,11 @@
                                     "session": {
                                         "type": "string",
                                         "description": "The session responsible for the component's current state"
+                                    },
+                                    "retry_policy": {
+                                        "type": "integer",
+                                        "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                        "example": 1
                                     }
                                 },
                                 "additionalProperties": false
@@ -4861,6 +5066,11 @@
                                 "polling_frequency": {
                                     "type": "integer",
                                     "description": "How frequently the BOS operators check component state for needed actions. (in seconds)"
+                                },
+                                "default_retry_policy": {
+                                    "type": "integer",
+                                    "description": "The default maximum number attempts per node for failed actions.",
+                                    "example": 1
                                 }
                             },
                             "additionalProperties": true
@@ -11425,10 +11635,25 @@
                                                     "action": {
                                                         "type": "string",
                                                         "description": "A description of the most recent operator/action to impact the component."
-                                                    },
-                                                    "num_attempts": {
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "event_stats": {
+                                                "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "power_on_attempts": {
                                                         "type": "integer",
-                                                        "description": "How many attempts have been made for this action."
+                                                        "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                                    },
+                                                    "power_off_graceful_attempts": {
+                                                        "type": "integer",
+                                                        "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                                    },
+                                                    "power_off_forceful_attempts": {
+                                                        "type": "integer",
+                                                        "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                                     }
                                                 },
                                                 "additionalProperties": false
@@ -11464,6 +11689,11 @@
                                             "session": {
                                                 "type": "string",
                                                 "description": "The session responsible for the component's current state"
+                                            },
+                                            "retry_policy": {
+                                                "type": "integer",
+                                                "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                                "example": 1
                                             }
                                         },
                                         "additionalProperties": false
@@ -11670,10 +11900,25 @@
                                                 "action": {
                                                     "type": "string",
                                                     "description": "A description of the most recent operator/action to impact the component."
-                                                },
-                                                "num_attempts": {
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "event_stats": {
+                                            "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "power_on_attempts": {
                                                     "type": "integer",
-                                                    "description": "How many attempts have been made for this action."
+                                                    "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                                },
+                                                "power_off_graceful_attempts": {
+                                                    "type": "integer",
+                                                    "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                                },
+                                                "power_off_forceful_attempts": {
+                                                    "type": "integer",
+                                                    "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                                 }
                                             },
                                             "additionalProperties": false
@@ -11709,6 +11954,11 @@
                                         "session": {
                                             "type": "string",
                                             "description": "The session responsible for the component's current state"
+                                        },
+                                        "retry_policy": {
+                                            "type": "integer",
+                                            "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                            "example": 1
                                         }
                                     },
                                     "additionalProperties": false
@@ -11865,10 +12115,25 @@
                                                     "action": {
                                                         "type": "string",
                                                         "description": "A description of the most recent operator/action to impact the component."
-                                                    },
-                                                    "num_attempts": {
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "event_stats": {
+                                                "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "power_on_attempts": {
                                                         "type": "integer",
-                                                        "description": "How many attempts have been made for this action."
+                                                        "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                                    },
+                                                    "power_off_graceful_attempts": {
+                                                        "type": "integer",
+                                                        "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                                    },
+                                                    "power_off_forceful_attempts": {
+                                                        "type": "integer",
+                                                        "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                                     }
                                                 },
                                                 "additionalProperties": false
@@ -11904,6 +12169,11 @@
                                             "session": {
                                                 "type": "string",
                                                 "description": "The session responsible for the component's current state"
+                                            },
+                                            "retry_policy": {
+                                                "type": "integer",
+                                                "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                                "example": 1
                                             }
                                         },
                                         "additionalProperties": false
@@ -12113,10 +12383,25 @@
                                                             "action": {
                                                                 "type": "string",
                                                                 "description": "A description of the most recent operator/action to impact the component."
-                                                            },
-                                                            "num_attempts": {
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "event_stats": {
+                                                        "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "power_on_attempts": {
                                                                 "type": "integer",
-                                                                "description": "How many attempts have been made for this action."
+                                                                "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                                            },
+                                                            "power_off_graceful_attempts": {
+                                                                "type": "integer",
+                                                                "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                                            },
+                                                            "power_off_forceful_attempts": {
+                                                                "type": "integer",
+                                                                "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                                             }
                                                         },
                                                         "additionalProperties": false
@@ -12152,6 +12437,11 @@
                                                     "session": {
                                                         "type": "string",
                                                         "description": "The session responsible for the component's current state"
+                                                    },
+                                                    "retry_policy": {
+                                                        "type": "integer",
+                                                        "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                                        "example": 1
                                                     }
                                                 },
                                                 "additionalProperties": false
@@ -12319,10 +12609,25 @@
                                                         "action": {
                                                             "type": "string",
                                                             "description": "A description of the most recent operator/action to impact the component."
-                                                        },
-                                                        "num_attempts": {
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "event_stats": {
+                                                    "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "power_on_attempts": {
                                                             "type": "integer",
-                                                            "description": "How many attempts have been made for this action."
+                                                            "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                                        },
+                                                        "power_off_graceful_attempts": {
+                                                            "type": "integer",
+                                                            "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                                        },
+                                                        "power_off_forceful_attempts": {
+                                                            "type": "integer",
+                                                            "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                                         }
                                                     },
                                                     "additionalProperties": false
@@ -12358,6 +12663,11 @@
                                                 "session": {
                                                     "type": "string",
                                                     "description": "The session responsible for the component's current state"
+                                                },
+                                                "retry_policy": {
+                                                    "type": "integer",
+                                                    "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                                    "example": 1
                                                 }
                                             },
                                             "additionalProperties": false
@@ -12516,10 +12826,25 @@
                                                     "action": {
                                                         "type": "string",
                                                         "description": "A description of the most recent operator/action to impact the component."
-                                                    },
-                                                    "num_attempts": {
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "event_stats": {
+                                                "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                                "type": "object",
+                                                "properties": {
+                                                    "power_on_attempts": {
                                                         "type": "integer",
-                                                        "description": "How many attempts have been made for this action."
+                                                        "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                                    },
+                                                    "power_off_graceful_attempts": {
+                                                        "type": "integer",
+                                                        "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                                    },
+                                                    "power_off_forceful_attempts": {
+                                                        "type": "integer",
+                                                        "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                                     }
                                                 },
                                                 "additionalProperties": false
@@ -12555,6 +12880,11 @@
                                             "session": {
                                                 "type": "string",
                                                 "description": "The session responsible for the component's current state"
+                                            },
+                                            "retry_policy": {
+                                                "type": "integer",
+                                                "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                                "example": 1
                                             }
                                         },
                                         "additionalProperties": false
@@ -12797,10 +13127,25 @@
                                                 "action": {
                                                     "type": "string",
                                                     "description": "A description of the most recent operator/action to impact the component."
-                                                },
-                                                "num_attempts": {
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "event_stats": {
+                                            "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "power_on_attempts": {
                                                     "type": "integer",
-                                                    "description": "How many attempts have been made for this action."
+                                                    "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                                },
+                                                "power_off_graceful_attempts": {
+                                                    "type": "integer",
+                                                    "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                                },
+                                                "power_off_forceful_attempts": {
+                                                    "type": "integer",
+                                                    "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                                 }
                                             },
                                             "additionalProperties": false
@@ -12836,6 +13181,11 @@
                                         "session": {
                                             "type": "string",
                                             "description": "The session responsible for the component's current state"
+                                        },
+                                        "retry_policy": {
+                                            "type": "integer",
+                                            "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                            "example": 1
                                         }
                                     },
                                     "additionalProperties": false
@@ -13075,10 +13425,25 @@
                                             "action": {
                                                 "type": "string",
                                                 "description": "A description of the most recent operator/action to impact the component."
-                                            },
-                                            "num_attempts": {
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "event_stats": {
+                                        "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "power_on_attempts": {
                                                 "type": "integer",
-                                                "description": "How many attempts have been made for this action."
+                                                "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                            },
+                                            "power_off_graceful_attempts": {
+                                                "type": "integer",
+                                                "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                            },
+                                            "power_off_forceful_attempts": {
+                                                "type": "integer",
+                                                "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                             }
                                         },
                                         "additionalProperties": false
@@ -13114,6 +13479,11 @@
                                     "session": {
                                         "type": "string",
                                         "description": "The session responsible for the component's current state"
+                                    },
+                                    "retry_policy": {
+                                        "type": "integer",
+                                        "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                        "example": 1
                                     }
                                 },
                                 "additionalProperties": false
@@ -13266,10 +13636,25 @@
                                                 "action": {
                                                     "type": "string",
                                                     "description": "A description of the most recent operator/action to impact the component."
-                                                },
-                                                "num_attempts": {
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "event_stats": {
+                                            "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "power_on_attempts": {
                                                     "type": "integer",
-                                                    "description": "How many attempts have been made for this action."
+                                                    "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                                },
+                                                "power_off_graceful_attempts": {
+                                                    "type": "integer",
+                                                    "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                                },
+                                                "power_off_forceful_attempts": {
+                                                    "type": "integer",
+                                                    "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                                 }
                                             },
                                             "additionalProperties": false
@@ -13305,6 +13690,11 @@
                                         "session": {
                                             "type": "string",
                                             "description": "The session responsible for the component's current state"
+                                        },
+                                        "retry_policy": {
+                                            "type": "integer",
+                                            "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                            "example": 1
                                         }
                                     },
                                     "additionalProperties": false
@@ -13506,10 +13896,25 @@
                                             "action": {
                                                 "type": "string",
                                                 "description": "A description of the most recent operator/action to impact the component."
-                                            },
-                                            "num_attempts": {
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "event_stats": {
+                                        "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                        "type": "object",
+                                        "properties": {
+                                            "power_on_attempts": {
                                                 "type": "integer",
-                                                "description": "How many attempts have been made for this action."
+                                                "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                            },
+                                            "power_off_graceful_attempts": {
+                                                "type": "integer",
+                                                "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                            },
+                                            "power_off_forceful_attempts": {
+                                                "type": "integer",
+                                                "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                             }
                                         },
                                         "additionalProperties": false
@@ -13545,6 +13950,11 @@
                                     "session": {
                                         "type": "string",
                                         "description": "The session responsible for the component's current state"
+                                    },
+                                    "retry_policy": {
+                                        "type": "integer",
+                                        "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                        "example": 1
                                     }
                                 },
                                 "additionalProperties": false
@@ -13697,10 +14107,25 @@
                                                 "action": {
                                                     "type": "string",
                                                     "description": "A description of the most recent operator/action to impact the component."
-                                                },
-                                                "num_attempts": {
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "event_stats": {
+                                            "description": "Information on the most recent attempt to return the node to its desired state.\n",
+                                            "type": "object",
+                                            "properties": {
+                                                "power_on_attempts": {
                                                     "type": "integer",
-                                                    "description": "How many attempts have been made for this action."
+                                                    "description": "How many attempts have been made to power-on since the last time the node was in the desired state."
+                                                },
+                                                "power_off_graceful_attempts": {
+                                                    "type": "integer",
+                                                    "description": "How many attempts have been made to power-off gracefully since the last time the node was in the desired state."
+                                                },
+                                                "power_off_forceful_attempts": {
+                                                    "type": "integer",
+                                                    "description": "How many attempts have been made to power-off forcefully since the last time the node was in the desired state."
                                                 }
                                             },
                                             "additionalProperties": false
@@ -13736,6 +14161,11 @@
                                         "session": {
                                             "type": "string",
                                             "description": "The session responsible for the component's current state"
+                                        },
+                                        "retry_policy": {
+                                            "type": "integer",
+                                            "description": "The maximum number attempts per action when actions fail.\nDefaults to the global default_retry_policy if not set\n",
+                                            "example": 1
                                         }
                                     },
                                     "additionalProperties": false
@@ -14045,6 +14475,11 @@
                                         "polling_frequency": {
                                             "type": "integer",
                                             "description": "How frequently the BOS operators check component state for needed actions. (in seconds)"
+                                        },
+                                        "default_retry_policy": {
+                                            "type": "integer",
+                                            "description": "The default maximum number attempts per node for failed actions.",
+                                            "example": 1
                                         }
                                     },
                                     "additionalProperties": true
@@ -14103,6 +14538,11 @@
                                     "polling_frequency": {
                                         "type": "integer",
                                         "description": "How frequently the BOS operators check component state for needed actions. (in seconds)"
+                                    },
+                                    "default_retry_policy": {
+                                        "type": "integer",
+                                        "description": "The default maximum number attempts per node for failed actions.",
+                                        "example": 1
                                     }
                                 },
                                 "additionalProperties": true
@@ -14150,6 +14590,11 @@
                                         "polling_frequency": {
                                             "type": "integer",
                                             "description": "How frequently the BOS operators check component state for needed actions. (in seconds)"
+                                        },
+                                        "default_retry_policy": {
+                                            "type": "integer",
+                                            "description": "The default maximum number attempts per node for failed actions.",
+                                            "example": 1
                                         }
                                     },
                                     "additionalProperties": true


### PR DESCRIPTION
## Summary and Scope

This adds the ability to set the retry limit options in the BOS v2 api, as well as the attempt counters for components in BOS v2.

## Issues and Related PRs

* Resolves CASMCMS-7876/CASMCMS-7848

## Testing

### Tested on:

  * The new additions were tested locally

### Test description:

Confirmed that the new fields were present in the api and that using them generated the correct json payload.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

