### PR TITLE
CASMCMS-8481: Make BOS V2 the default for the CLI

### DIFF
--- a/cray/modules/bos/cli.py
+++ b/cray/modules/bos/cli.py
@@ -37,8 +37,8 @@ SWAGGER_OPTS = {
 
 cli = generate(__file__, swagger_opts=SWAGGER_OPTS)
 
-# Place the v1 commands at the 'cray bos' level of the cli
-CURRENT_VERSION = 'v1'
+# Place the v2 commands at the 'cray bos' level of the cli
+CURRENT_VERSION = 'v2'
 PRESERVE_VERSIONS = True
 
 if PRESERVE_VERSIONS:

--- a/tests/test_modules/test_bos.py
+++ b/tests/test_modules/test_bos.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 
 MIT License
 
-(C) Copyright [2020-2021] Hewlett Packard Enterprise Development LP
+(C) Copyright [2020-2023] Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -53,7 +53,7 @@ from ..utils.runner import cli_runner  # pylint: disable=unused-import
 from ..utils.rest import rest_mock  # pylint: disable=unused-import
 from ..utils.utils import compare_dicts
 
-DEFAULT_BOS_VERSION = 'v1'
+DEFAULT_BOS_VERSION = 'v2'
 
 
 # pylint: disable=redefined-outer-name


### PR DESCRIPTION
## Summary and Scope

Make BOS V2 the default for the CLI## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `gamora`

### Test description:

I updated the unit tests which passed.
I scp'ed a copy of the crayci RPM onto gamora. I invoked it as follows. This demonstrates that 'v2' is now the default version when none is specified.

ncn-m001:/mnt/developer/jasons/delete # ./usr/bin/cray bos sessions list
results = []

ncn-m001:/mnt/developer/jasons/delete # ./usr/bin/cray bos session list
Usage: cray bos [OPTIONS] COMMAND [ARGS]...
Try 'cray bos --help' for help.

Error: No such command 'session'.

ncn-m001:/mnt/developer/jasons/delete # ./usr/bin/cray bos v2 sessions list
results = []

ncn-m001:/mnt/developer/jasons/delete # ./usr/bin/cray bos v1 session list
results = [ "071500a5-e43c-4c89-8118-b0d1214cb401",]


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
Medium. We may break people's scripts if they used the Cray CLI without specifying a version, which we have warned them not to do.

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

