### PR TITLE
CASMTRIAGE-5282 Downgrade `botocore`

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -32,6 +32,10 @@ if (env.BRANCH_NAME ==~ ~"^PR-\\d+") {
     currentBuild.result = 'SUCCESS'
     echo "Pull-Request builds are skipped."
     return
+} else if (env.BRANCH_NAME ==~ ~"^dependabot/github_actions") {
+    currentBuild.result = 'SUCCESS'
+    echo "Dependabot GitHub action builds are skipped."
+    return
 }
 
 // Only consider X.Y.Z and X.Y.Z.postN tags as stable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,10 @@ classifiers = [
 ]
 description = 'Cray management and workflow tool'
 dependencies = [
-    'boto3~=1.26',
-    'botocore~=1.29',
+    # DO NOT UPDATE the below boto3 and botocore - Breaks cray artifacts bucket list
+    'boto3<1.24',
+    'botocore<1.27',
+    # DO NOT UPDATE the above boto3 and botocore - Breaks cray artifacts bucket list
     'click==7.1.2',
     'oauthlib~=3.2',
     'requests-oauthlib~=1.3',


### PR DESCRIPTION


### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-5282

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
`botocore>=1.29.15` contains a change that breaks the `cray artifacts buckets list` command.

`boto3>=1.26` refers to the above, breaking change so it must also be downgraded.

Pin `boto3` and `botocore` to the last good version before the breaking change, until we can more or less fix it.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)
 

```bash
ncn-m002:~ # export CRAY_CREDENTIALS=/tmp/cmsdev-cray-credentials-file.810384.json
ncn-m002:~ # cray artifacts buckets list --format json
[
  "admin-tools",
  "badger",
  "boot-images",
  "config-data",
  "etcd-backup",
  "fw-update",
  "ims",
  "install-artifacts",
  "nmd",
  "postgres-backup",
  "sat",
  "sds",
  "sls",
  "sma",
  "ssd",
  "ssm",
  "thanos",
  "user",
  "velero",
  "wlm"
]
ncn-m002:~ # cray --version
cray, version 0.80.0.post2.dev1+g7c0872e
```

### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
