### PR TITLE
Build using arti.hpc instead of arti.dev

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -31,7 +31,7 @@ pipeline {
                 docker {
                     label "metal-gcp-builder"
                     reuseNode true
-                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp2_build_environment:latest"
+                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp2_build_environment:latest"
                     // Run as root
                     args "-u root"
                 }
@@ -48,7 +48,7 @@ pipeline {
                 docker {
                     label "metal-gcp-builder"
                     reuseNode true
-                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
+                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
                     // Run as root
                     args "-u root"
                 }


### PR DESCRIPTION
Not sure if this change is necessary, but I noticed it when I was debugging the build failure.