### PR TITLE
CASMINST-6387 Fix `cray` Pyinstaller

### DIFF
--- a/cray/cli.py
+++ b/cray/cli.py
@@ -27,6 +27,7 @@
 
 import os
 import re
+import sys
 import click
 
 from cray.auth import AuthUsername
@@ -43,7 +44,7 @@ from cray.echo import LOG_FORCE
 from cray.formatting import format_result
 from cray.utils import get_hostname
 
-CONTEXT_SETTING = {
+CONTEXT_SETTINGS = {
     'obj': {
         'config_dir': '',
         'globals': {},
@@ -55,7 +56,6 @@ CONTEXT_SETTING = {
     'help_option_names': ['-h', '--help'],
 }
 
-CONTEXT_SETTINGS = {}
 
 def rsa_required(config):
     """Get the value for 'auth.login.rsa_required' from the CLI
@@ -83,10 +83,9 @@ def rsa_required(config):
 @group(
     cls=GeneratedCommands,
     base_path=os.path.dirname(__file__),
-    context_settings=CONTEXT_SETTING
+    context_settings=CONTEXT_SETTINGS
 )  # pragma: NO COVER
 @click.pass_context
-@click.version_option()
 def cli(ctx, *args, **kwargs):
     """ Cray management and workflow tool"""
     pass
@@ -215,3 +214,11 @@ def cli_cb(ctx, result, **kwargs):
     # Use click echo instead of our logging because we always want to echo
     # our results
     click.echo(format_result(result, ctx.obj['globals'].get('format')))
+
+
+# Handle the usage of ``cli`` for Pyinstaller.
+if getattr(sys, 'frozen', False):
+    click.version_option()(cli)
+    cli(sys.argv[1:])
+else:
+    click.version_option()(cli)


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-6387

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The `pyinstaller` build for `craycli` is producing an invalid binary that returns nothing (no flags or commands produce any output).

This block of code was removed in #100, and part of it needs to be returned.

This also cleans up the dual `CONTEXT_SETTING` and `CONTEXT_SETTINGS`.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 

RPM works:
```bash
8c3614bd6d2f:/mnt # rpm -Uvh craycli-0.81.2.dev1+ge402bd0-1.x86_64.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:craycli-0.81.2.dev1+ge402bd0-1   c################################# [100%]
8c3614bd6d2f:/mnt # cray
cray -hUsage: cray [OPTIONS] COMMAND [ARGS]...

  Cray management and workflow tool

Options:
  --version   Show the version and exit.
  -h, --help  Show this message and exit.

Groups:
  artifacts  Manage artifacts in S3
  auth       Manage OAuth2 credentials for the Cray CLI
  badger     Badger Service API
  bos        Boot Orchestration Service
  bss        Boot Script Service
  capmc      Cray Advanced Platform Monitoring and Control (CAPMC)
  cfs        Configuration Framework Service
  config     View and edit Cray configuration properties
  cps        Content Projection Service
  fas        Firmware Action Service
  hsm        Hardware State Manager API
  ims        Image Management Service
  nmd        Node Memory Dump Service
  power      Power Control Service (PCS)
  scsd       System Configuration Service
  sls        System Layout Service
  uas        User Access Service
  vnid       Virtual Network Identifier Daemon

Commands:
  init  Initialize/reinitialize the Cray CLI
8c3614bd6d2f:/mnt # cray -h
cray --helUsage: cray [OPTIONS] COMMAND [ARGS]...

  Cray management and workflow tool

Options:
  --version   Show the version and exit.
  -h, --help  Show this message and exit.

Groups:
  artifacts  Manage artifacts in S3
  auth       Manage OAuth2 credentials for the Cray CLI
  badger     Badger Service API
  bos        Boot Orchestration Service
  bss        Boot Script Service
  capmc      Cray Advanced Platform Monitoring and Control (CAPMC)
  cfs        Configuration Framework Service
  config     View and edit Cray configuration properties
  cps        Content Projection Service
  fas        Firmware Action Service
  hsm        Hardware State Manager API
  ims        Image Management Service
  nmd        Node Memory Dump Service
  power      Power Control Service (PCS)
  scsd       System Configuration Service
  sls        System Layout Service
  uas        User Access Service
  vnid       Virtual Network Identifier Daemon

Commands:
  init  Initialize/reinitialize the Cray CLI
p8c3614bd6d2f:/mnt # cray --help
cray --versionUsage: cray [OPTIONS] COMMAND [ARGS]...

  Cray management and workflow tool

Options:
  --version   Show the version and exit.
  -h, --help  Show this message and exit.

Groups:
  artifacts  Manage artifacts in S3
  auth       Manage OAuth2 credentials for the Cray CLI
  badger     Badger Service API
  bos        Boot Orchestration Service
  bss        Boot Script Service
  capmc      Cray Advanced Platform Monitoring and Control (CAPMC)
  cfs        Configuration Framework Service
  config     View and edit Cray configuration properties
  cps        Content Projection Service
  fas        Firmware Action Service
  hsm        Hardware State Manager API
  ims        Image Management Service
  nmd        Node Memory Dump Service
  power      Power Control Service (PCS)
  scsd       System Configuration Service
  sls        System Layout Service
  uas        User Access Service
  vnid       Virtual Network Identifier Daemon

Commands:
  init  Initialize/reinitialize the Cray CLI

8c3614bd6d2f:/mnt # cray --version
cray, version 0.81.2.dev1+ge402bd0
```

### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
