### PR TITLE
CASMCMS-8624: Removing defaults for ims `kernel_file_name`

### DIFF
--- a/cray/modules/ims/openapi.yaml
+++ b/cray/modules/ims/openapi.yaml
@@ -2232,7 +2232,6 @@ components:
           minLength: 1
         kernel_file_name:
           description: Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.
-          default: vmlinuz
           example: vmlinuz
           type: string
           minLength: 1

--- a/cray/modules/ims/swagger3.json
+++ b/cray/modules/ims/swagger3.json
@@ -3096,7 +3096,6 @@
                                             },
                                             "kernel_file_name": {
                                                 "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                                "default": "vmlinuz",
                                                 "example": "vmlinuz",
                                                 "type": "string",
                                                 "minLength": 1
@@ -3356,7 +3355,6 @@
                                     },
                                     "kernel_file_name": {
                                         "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                        "default": "vmlinuz",
                                         "example": "vmlinuz",
                                         "type": "string",
                                         "minLength": 1
@@ -3567,7 +3565,6 @@
                                         },
                                         "kernel_file_name": {
                                             "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                            "default": "vmlinuz",
                                             "example": "vmlinuz",
                                             "type": "string",
                                             "minLength": 1
@@ -4029,7 +4026,6 @@
                                         },
                                         "kernel_file_name": {
                                             "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                            "default": "vmlinuz",
                                             "example": "vmlinuz",
                                             "type": "string",
                                             "minLength": 1
@@ -4326,7 +4322,6 @@
                                         },
                                         "kernel_file_name": {
                                             "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                            "default": "vmlinuz",
                                             "example": "vmlinuz",
                                             "type": "string",
                                             "minLength": 1
@@ -10659,7 +10654,6 @@
                                             },
                                             "kernel_file_name": {
                                                 "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                                "default": "vmlinuz",
                                                 "example": "vmlinuz",
                                                 "type": "string",
                                                 "minLength": 1
@@ -10919,7 +10913,6 @@
                                     },
                                     "kernel_file_name": {
                                         "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                        "default": "vmlinuz",
                                         "example": "vmlinuz",
                                         "type": "string",
                                         "minLength": 1
@@ -11130,7 +11123,6 @@
                                         },
                                         "kernel_file_name": {
                                             "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                            "default": "vmlinuz",
                                             "example": "vmlinuz",
                                             "type": "string",
                                             "minLength": 1
@@ -11593,7 +11585,6 @@
                                         },
                                         "kernel_file_name": {
                                             "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                            "default": "vmlinuz",
                                             "example": "vmlinuz",
                                             "type": "string",
                                             "minLength": 1
@@ -11890,7 +11881,6 @@
                                         },
                                         "kernel_file_name": {
                                             "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                            "default": "vmlinuz",
                                             "example": "vmlinuz",
                                             "type": "string",
                                             "minLength": 1
@@ -15412,7 +15402,6 @@
                                             },
                                             "kernel_file_name": {
                                                 "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                                "default": "vmlinuz",
                                                 "example": "vmlinuz",
                                                 "type": "string",
                                                 "minLength": 1
@@ -15672,7 +15661,6 @@
                                     },
                                     "kernel_file_name": {
                                         "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                        "default": "vmlinuz",
                                         "example": "vmlinuz",
                                         "type": "string",
                                         "minLength": 1
@@ -15883,7 +15871,6 @@
                                         },
                                         "kernel_file_name": {
                                             "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                            "default": "vmlinuz",
                                             "example": "vmlinuz",
                                             "type": "string",
                                             "minLength": 1
@@ -16346,7 +16333,6 @@
                                         },
                                         "kernel_file_name": {
                                             "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                            "default": "vmlinuz",
                                             "example": "vmlinuz",
                                             "type": "string",
                                             "minLength": 1
@@ -16643,7 +16629,6 @@
                                         },
                                         "kernel_file_name": {
                                             "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                                            "default": "vmlinuz",
                                             "example": "vmlinuz",
                                             "type": "string",
                                             "minLength": 1
@@ -18199,7 +18184,6 @@
                     },
                     "kernel_file_name": {
                         "description": "Name of the kernel file to extract and upload to the artifact repository from the /boot directory of the image root.",
-                        "default": "vmlinuz",
                         "example": "vmlinuz",
                         "type": "string",
                         "minLength": 1

--- a/cray/tests/test_modules/test_ims.py
+++ b/cray/tests/test_modules/test_ims.py
@@ -26,8 +26,8 @@ and options. """
 # pylint: disable=unused-argument
 # pylint: disable=invalid-name
 
-import os
 import json
+import os
 
 from cray.tests.utils import new_random_string
 
@@ -747,6 +747,46 @@ def test_cray_ims_jobs_create_create(cli_runner, rest_mock):
         'artifact_id': test_artifact_id,
         'initrd_file_name': test_initrd_file_name,
         'kernel_file_name': test_kernel_file_name,
+        'image_root_archive_name': test_image_root_archive_name,
+        'kernel_parameters_file_name': 'kernel-parameters',
+        'job_type': test_job_type,
+        'require_dkms': test_require_dkms,
+    }
+
+def test_cray_ims_jobs_create_create_kernel_file_none(cli_runner, rest_mock):
+    """ Test cray ims jobs create ... happy path shouldn't require kernel_file_name """
+    runner, cli, config = cli_runner
+    test_build_env_size = '15'
+    test_enable_debug = 'True'
+    test_public_key = new_random_string()
+    test_artifact_id = new_random_string()
+    test_initrd_file_name = new_random_string()
+    test_image_root_archive_name = new_random_string()
+    test_job_type = "create"
+    test_require_dkms = True
+    result = runner.invoke(
+        cli,
+        ['ims', 'jobs', 'create',
+         '--build-env-size', test_build_env_size,
+         '--enable-debug', test_enable_debug,
+         '--public-key-id', test_public_key,
+         '--artifact-id', test_artifact_id,
+         '--initrd-file-name', test_initrd_file_name,
+         '--image-root-archive-name', test_image_root_archive_name,
+         '--job-type', test_job_type,
+         '--require-dkms', test_require_dkms]
+
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data['method'] == 'POST'
+    assert data['url'] == f'{config["default"]["hostname"]}/apis/ims/v3/jobs'
+    assert data['body'] == {
+        'build_env_size': int(test_build_env_size),
+        'enable_debug': True,
+        'public_key_id': test_public_key,
+        'artifact_id': test_artifact_id,
+        'initrd_file_name': test_initrd_file_name,
         'image_root_archive_name': test_image_root_archive_name,
         'kernel_parameters_file_name': 'kernel-parameters',
         'job_type': test_job_type,


### PR DESCRIPTION
IMS will determine the correct filename if none is provided at CLI invoking with no --kernel-file-name based on the architecture.

### Summary and Scope

- Fixes: https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8624
- Relates to: https://github.com/Cray-HPE/ims/pull/76

#### Issue Type

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
