### PR TITLE
CASMCMS-8674: Remove BOS templateUrl parameter

### DIFF
--- a/cray/modules/bos/openapi.yaml
+++ b/cray/modules/bos/openapi.yaml
@@ -427,12 +427,6 @@ components:
 
         * self : The session object
       properties:
-        templateUrl:
-          type: string
-          description: |
-            The URL to the resource providing the session template data.
-            Specify either a templateURL, or the other session
-            template parameters.
         name:
           type: string
           description: Name of the SessionTemplate. The length of the name is restricted to 45 characters.

--- a/cray/modules/bos/swagger3.json
+++ b/cray/modules/bos/swagger3.json
@@ -578,10 +578,6 @@
         "type": "object",
         "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which when combined with an\naction (i.e. boot, reconfigure, reboot, shutdown) will create a Kubernetes BOA job\nto complete the required tasks for the operation.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
         "properties": {
-          "templateUrl": {
-            "type": "string",
-            "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
-          },
           "name": {
             "type": "string",
             "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
@@ -3929,10 +3925,6 @@
               "type": "object",
               "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which when combined with an\naction (i.e. boot, reconfigure, reboot, shutdown) will create a Kubernetes BOA job\nto complete the required tasks for the operation.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
               "properties": {
-                "templateUrl": {
-                  "type": "string",
-                  "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
-                },
                 "name": {
                   "type": "string",
                   "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
@@ -5568,10 +5560,6 @@
                 "type": "object",
                 "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which when combined with an\naction (i.e. boot, reconfigure, reboot, shutdown) will create a Kubernetes BOA job\nto complete the required tasks for the operation.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
                 "properties": {
-                  "templateUrl": {
-                    "type": "string",
-                    "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
-                  },
                   "name": {
                     "type": "string",
                     "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
@@ -5742,10 +5730,6 @@
                   "type": "object",
                   "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which when combined with an\naction (i.e. boot, reconfigure, reboot, shutdown) will create a Kubernetes BOA job\nto complete the required tasks for the operation.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
                   "properties": {
-                    "templateUrl": {
-                      "type": "string",
-                      "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
-                    },
                     "name": {
                       "type": "string",
                       "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
@@ -5966,10 +5950,6 @@
                     "type": "object",
                     "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which when combined with an\naction (i.e. boot, reconfigure, reboot, shutdown) will create a Kubernetes BOA job\nto complete the required tasks for the operation.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
                     "properties": {
-                      "templateUrl": {
-                        "type": "string",
-                        "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
-                      },
                       "name": {
                         "type": "string",
                         "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
@@ -6164,10 +6144,6 @@
                   "type": "object",
                   "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which when combined with an\naction (i.e. boot, reconfigure, reboot, shutdown) will create a Kubernetes BOA job\nto complete the required tasks for the operation.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
                   "properties": {
-                    "templateUrl": {
-                      "type": "string",
-                      "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
-                    },
                     "name": {
                       "type": "string",
                       "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",
@@ -6440,10 +6416,6 @@
                   "type": "object",
                   "description": "A Session Template object represents a collection of resources and metadata.\nA session template is used to create a Session which when combined with an\naction (i.e. boot, reconfigure, reboot, shutdown) will create a Kubernetes BOA job\nto complete the required tasks for the operation.\n\nA Session Template can be created from a JSON structure.  It will return\na SessionTemplate name if successful.\nThis name is required when creating a Session.\n\n## Link Relationships\n\n* self : The session object\n",
                   "properties": {
-                    "templateUrl": {
-                      "type": "string",
-                      "description": "The URL to the resource providing the session template data.\nSpecify either a templateURL, or the other session\ntemplate parameters.\n"
-                    },
                     "name": {
                       "type": "string",
                       "description": "Name of the SessionTemplate. The length of the name is restricted to 45 characters.",

--- a/cray/tests/test_modules/test_bos.py
+++ b/cray/tests/test_modules/test_bos.py
@@ -149,7 +149,7 @@ def test_cray_bos_sessiontemplate_create_full(cli_runner, rest_mock):
         cli,
         ['bos', 'v1', 'sessiontemplate', 'create', '--name', 'foo',
          '--partition', 'bar', '--enable-cfs', True, '--cfs-configuration',
-         'test-config', '--description', 'desc', '--template-url', 'test-url']
+         'test-config', '--description', 'desc']
     )
     assert result.exit_code == 0
     data = json.loads(result.output)
@@ -161,8 +161,7 @@ def test_cray_bos_sessiontemplate_create_full(cli_runner, rest_mock):
         'partition': 'bar',
         'enable_cfs': True,
         'cfs': {'configuration': 'test-config'},
-        'description': 'desc',
-        'templateUrl': 'test-url',
+        'description': 'desc'
     }
     compare_dicts(expected, data['body'])
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [CASMCMS-8674](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8674)

#### Issue Type

- Bugfix Pull Request

The `templateUrl` parameter has been broken in BOS since CSM 1.2. Since it has not been reported by anyone in that time, we're removing it from BOS. This PR removes it from the CLI as well.

### Prerequisites

- [X] should not merge until [this PR](https://github.com/Cray-HPE/bos/pull/158) merges
- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

I tested this on fanta along with the accompanying updated BOS. I ran the cmsdev bos test suite, and also tested creating and deleting v1 session templates.
 
### Risks and Mitigations

Low risk -- the parameter already doesn't work.
 