### PR TITLE
CASMCMS-8599: Add CLI support for `--include-disabled` option on v2 session creation

### DIFF
--- a/cray/modules/bos/openapi.yaml
+++ b/cray/modules/bos/openapi.yaml
@@ -727,6 +727,11 @@ components:
             Set to stage a session which will not immediately change the state of any components.
             The "applystaged" endpoint can be called at a later time to trigger the start of this session.
           default: false
+        include_disabled:
+          type: boolean
+          description: |
+            Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).
+          default: false
       required: [operation, template_name]
       additionalProperties: false
     V2SessionStatus:
@@ -864,6 +869,10 @@ components:
             A comma-separated list of nodes, representing the initial list of nodes
             the session should operate against.  The list will remain even if
             other sessions have taken over management of the nodes.
+        include_disabled:
+          type: boolean
+          description: |
+            Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).
         status:
           $ref: '#/components/schemas/V2SessionStatus'
       additionalProperties: false

--- a/cray/modules/bos/swagger3.json
+++ b/cray/modules/bos/swagger3.json
@@ -1292,6 +1292,11 @@
             "type": "boolean",
             "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n",
             "default": false
+          },
+          "include_disabled": {
+            "type": "boolean",
+            "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n",
+            "default": false
           }
         },
         "required": [
@@ -1437,6 +1442,10 @@
             "type": "string",
             "description": "A comma-separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
           },
+          "include_disabled": {
+            "type": "boolean",
+            "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n"
+          },
           "status": {
             "type": "object",
             "description": "Information on the status of a session.\n",
@@ -1505,6 +1514,10 @@
             "components": {
               "type": "string",
               "description": "A comma-separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
+            },
+            "include_disabled": {
+              "type": "boolean",
+              "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n"
             },
             "status": {
               "type": "object",
@@ -2659,6 +2672,11 @@
                   "type": "boolean",
                   "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n",
                   "default": false
+                },
+                "include_disabled": {
+                  "type": "boolean",
+                  "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n",
+                  "default": false
                 }
               },
               "required": [
@@ -3658,6 +3676,10 @@
                   "type": "boolean",
                   "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
                 },
+                "include_disabled": {
+                  "type": "boolean",
+                  "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n"
+                },
                 "components": {
                   "type": "string",
                   "description": "A comma-separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
@@ -4410,6 +4432,10 @@
                   "type": "boolean",
                   "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
                 },
+                "include_disabled": {
+                  "type": "boolean",
+                  "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n"
+                },
                 "components": {
                   "type": "string",
                   "description": "A comma-separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
@@ -4485,6 +4511,10 @@
                   "stage": {
                     "type": "boolean",
                     "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                  },
+                  "include_disabled": {
+                    "type": "boolean",
+                    "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n"
                   },
                   "components": {
                     "type": "string",
@@ -10429,6 +10459,11 @@
                     "type": "boolean",
                     "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n",
                     "default": false
+                  },
+                  "include_disabled": {
+                    "type": "boolean",
+                    "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n",
+                    "default": false
                   }
                 },
                 "required": [
@@ -10475,6 +10510,10 @@
                     "stage": {
                       "type": "boolean",
                       "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                    },
+                    "include_disabled": {
+                      "type": "boolean",
+                      "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n"
                     },
                     "components": {
                       "type": "string",
@@ -10632,6 +10671,10 @@
                       "stage": {
                         "type": "boolean",
                         "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                      },
+                      "include_disabled": {
+                        "type": "boolean",
+                        "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n"
                       },
                       "components": {
                         "type": "string",
@@ -10805,6 +10848,10 @@
                       "type": "boolean",
                       "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
                     },
+                    "include_disabled": {
+                      "type": "boolean",
+                      "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n"
+                    },
                     "components": {
                       "type": "string",
                       "description": "A comma-separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
@@ -10928,6 +10975,10 @@
                     "type": "boolean",
                     "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
                   },
+                  "include_disabled": {
+                    "type": "boolean",
+                    "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n"
+                  },
                   "components": {
                     "type": "string",
                     "description": "A comma-separated list of nodes, representing the initial list of nodes the session should operate against.  The list will remain even if other sessions have taken over management of the nodes.\n"
@@ -11001,6 +11052,10 @@
                     "stage": {
                       "type": "boolean",
                       "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                    },
+                    "include_disabled": {
+                      "type": "boolean",
+                      "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n"
                     },
                     "components": {
                       "type": "string",
@@ -11364,6 +11419,10 @@
                     "stage": {
                       "type": "boolean",
                       "description": "Set to stage a session which will not immediately change the state of any components. The \"applystaged\" endpoint can be called at a later time to trigger the start of this session.\n"
+                    },
+                    "include_disabled": {
+                      "type": "boolean",
+                      "description": "Set to include nodes that have been disabled as indicated in the Hardware State Manager (HSM).\n"
                     },
                     "components": {
                       "type": "string",

--- a/cray/tests/test_modules/test_bos.py
+++ b/cray/tests/test_modules/test_bos.py
@@ -271,7 +271,38 @@ def test_cray_bos_session_create(cli_runner, rest_mock):
         }, data['body']
     )
 
+# pylint: disable=redefined-outer-name
+def test_cray_bos_v2_sessions_create(cli_runner, rest_mock):
+    """ Test cray bos create v2 session ... happy path """
+    runner, cli, config = cli_runner
+    result = runner.invoke(
+        cli,
+        ['bos', 'v2', 'sessions', 'create',
+         '--template-name', 'foo',
+         '--name', 'bar',
+         '--limit', 'harf,blah',
+         '--stage', 'true',
+         '--include-disabled', 'true',
+         '--operation', 'boot']
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data['method'] == 'POST'
+    assert data['url'] == f'{config["default"]["hostname"]}' \
+                          f'/apis/bos/v2/sessions'
+    compare_dicts(
+        {
+            'template_name': 'foo',
+            'name': 'bar',
+            'limit': 'harf,blah',
+            'stage': True,
+            'include_disabled': True,
+            'operation': 'boot',
+        },
+        data['body']
+    )
 
+# pylint: disable=redefined-outer-name
 def test_cray_bos_session_create_missing_required(cli_runner, rest_mock):
     """ Test cray bos create session ... when a required parameter is missing
 


### PR DESCRIPTION
### Summary and Scope

- Fixes: https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8599

#### Issue Type

- RFE Pull Request

Adds --include-disabled CLI option, and adds a v2 session create test which includes it.

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)

Testing underway currently. Will update shortly.

### Risks and Mitigations
 
Low risk. Adding a single new flag to a single BOS CLI operation.