### PR TITLE
Remove required tenant prompt when initializing (CASMPET-6649)

### DIFF
--- a/cray/cli.py
+++ b/cray/cli.py
@@ -98,7 +98,7 @@ def cli(ctx, *args, **kwargs):
     help='Hostname of Cray system.'
 )
 @option(
-    "--tenant", default=None, no_global=True,
+    "--tenant", default="", no_global=True,
     help='Tenant name to scope requests for.'
 )
 @option(
@@ -142,17 +142,6 @@ def init(ctx, hostname, no_auth, overwrite, tenant, **kwargs):
     # Add https if doesn't exist at all
     if not re.match("^http(s)?://", hostname):
         hostname = f'https://{hostname}'
-
-    if tenant is None:
-        tenant = ctx.obj.get(
-            'config',
-            {}
-        ).get(
-            'core.tenant',
-            click.prompt('Tenant Name (leave blank for global scope):',
-                         default="",
-                         type=str)
-        )
 
     initialize_dirs(config_dir)  # No error if directories already exist
     config = Config(config_dir, configuration, raise_err=False)


### PR DESCRIPTION
### Summary and Scope

Change --tenant argument to be optional to prevent BW incompatible change for non-interactive use cases.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6649

### Testing

Tested on ashton:

```
ncn-m003:~/.config/cray/configurations # cray init --hostname https://api-gw-service-nmn.local
Overwrite configuration file at: /root/.config/cray/configurations/default ? [y/N]: y
Username: vshasta
Password:
Success!

Initialization complete.
ncn-m003:~/.config/cray/configurations # cat default
[core]
hostname = "https://api-gw-service-nmn.local"
tenant = ""

[auth.login]
username = "vshasta"
```

```
ncn-m003:~/.config/cray/configurations # cray init --hostname https://api-gw-service-nmn.local --tenant vcluster-blue
Overwrite configuration file at: /root/.config/cray/configurations/default ? [y/N]: y
Username: vshasta
Password:
Success!

Initialization complete.

ncn-m003:~/.config/cray/configurations # cat default
[core]
hostname = "https://api-gw-service-nmn.local"
tenant = "vcluster-blue"

[auth.login]
username = "vshasta"
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
