### PR TITLE
Change cray artifacts to return more than 1000 files (CASMPET-6168)

### DIFF
--- a/cray/modules/artifacts/cli.py
+++ b/cray/modules/artifacts/cli.py
@@ -111,7 +111,15 @@ def list_objects(ctx, bucket):
     # Load config to make sure it exists.
     s3client = get_s3_client()
     try:
-        files = s3client.list_objects(Bucket=bucket).get('Contents', [])
+        files = []
+        paginator = s3client.get_paginator('list_objects')
+        pages = paginator.paginate(Bucket=bucket)
+
+        for page in pages:
+            if 'Contents' in page:
+                for obj in page['Contents']:
+                    files.append(obj)
+
     except (s3client.exceptions.NoSuchBucket, ClientError) as err:
         sys.exit(str(err))
     return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ dependencies = [
     'boto3<1.24',
     'botocore<1.27',
     # DO NOT UPDATE the above boto3 and botocore - Breaks cray artifacts bucket list
+    # DO NOT UPDATE the below urllib3 - Breaks cray artifacts list <bucket> pagination
+    # https://github.com/boto/botocore/issues/2926
+    'urllib3>=1.25.4,<1.27',
+    # DO NOT UPDATE the above urllib3 - Breaks cray artifacts list <bucket> pagination
     'click==7.1.2',
     'oauthlib~=3.2',
     'requests-oauthlib~=1.3',


### PR DESCRIPTION
### Summary and Scope

Use boto3 pagination api to fully list bucket contents.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6168

### Testing

mug:

Before:

```
cray artifacts list thanos | grep ^Key | wc -l
1000

cray artifacts list velero | grep ^Key | wc -l
1000
```

After:
```
cray artifacts list thanos | grep ^Key | wc -l
1583

cray artifacts list velero | grep ^Key | wc -l
2913
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
