### PR TITLE
Add tenant name header allowing other headers (CASMINST-6514)

### DIFF
--- a/cray/constants.py
+++ b/cray/constants.py
@@ -44,6 +44,8 @@ HIDDEN_TAG = "cli_hidden"
 DANGER_TAG = "cli_danger"
 FROM_FILE_TAG = "cli_from_file"
 CONVERSION_FLAG = "cray_converted"
+HEADER_ORIGIN = "header"
+HEADERS_ORIGIN = "headers"
 
 # Config constants
 DEFAULT_CONFIG = 'default'
@@ -52,3 +54,6 @@ EMPTY_CONFIG = ''
 CONFIG_DIR_NAME = 'configurations'
 LOG_DIR_NAME = 'logs'
 AUTH_DIR_NAME = 'tokens'
+
+# Rest constants
+TENANT_HEADER_NAME_KEY = "Cray-Tenant-Name"

--- a/cray/generator.py
+++ b/cray/generator.py
@@ -37,6 +37,8 @@ from cray import swagger
 from cray.constants import CONVERSION_FLAG
 from cray.constants import DANGER_TAG
 from cray.constants import FROM_FILE_TAG
+from cray.constants import HEADER_ORIGIN
+from cray.constants import HEADERS_ORIGIN
 from cray.constants import HIDDEN_TAG
 from cray.constants import IGNORE_TAG
 from cray.constants import TAG_SPLIT
@@ -44,7 +46,6 @@ from cray.nesteddict import NestedDict
 
 PATH_ORIGIN = 'path'
 QUERY_ORIGIN = 'query'
-HEADER_ORIGIN = 'header'
 PARAM_ORIGIN = 'params'
 FILE_ORIGIN = 'filepath'
 
@@ -169,7 +170,7 @@ def _parse_data(data, base=None, **kwargs):
     if opts[QUERY_ORIGIN]:
         args['params'] = opts[QUERY_ORIGIN]
     if opts[HEADER_ORIGIN]:
-        args['headers'] = opts[HEADER_ORIGIN]
+        args[HEADERS_ORIGIN] = opts[HEADER_ORIGIN]
     if opts[FILE_ORIGIN]:
         fields = {}
         for k, v in opts[FILE_ORIGIN].items():
@@ -177,7 +178,7 @@ def _parse_data(data, base=None, **kwargs):
             # pylint: disable=consider-using-with
             fields[k] = (os.path.basename(v), open(v, 'rb'))
         args['data'] = MultipartEncoder(fields=fields)
-        args.setdefault('headers', {})['Content-Type'] = args[
+        args.setdefault(HEADERS_ORIGIN, {})['Content-Type'] = args[
             'data'].content_type
     return (method, route, args)
 

--- a/cray/utils.py
+++ b/cray/utils.py
@@ -78,17 +78,8 @@ def get_tenant(ctx=None):
     """ Get the tenant requests are scoped to (None if not scoped to a tenant) """
     ctx = ctx or click.get_current_context()
     config = ctx.obj['config']
-    tenant = config.get('core.tenant', None)
+    tenant = config.get('core.tenant', "")
     return tenant
-
-def get_headers(ctx=None):
-    """ Get the headers which may or may not contain a tenant """
-    headers={}
-    ctx = ctx or click.get_current_context()
-    tenant = get_tenant(ctx=ctx)
-    if tenant:
-        headers={"Cray-Tenant-Name":tenant}
-    return headers
 
 
 def hostname_to_name(hostname=None, ctx=None):


### PR DESCRIPTION
### Summary and Scope

Change how tenant name header is passed to also work with other headers.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMINST-6514

### Testing

mug:

```
ncn-w004:~/.config/cray/configurations # cray uas create --publickey ~/.ssh/id_rsa.pub --format toml -vvvv
Loaded token: /root/.config/cray/tokens/api_gw_service_nmn_local.vers
REQUEST: POST to https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas
OPTIONS: {'params': {'imagename': None, 'ports': None}, 'data': <MultipartEncoder: {'publickey': ('id_rsa.pub', <_io.BufferedReader name='/root/.ssh/id_rsa.pub'>)}>, 'headers': {'Content-Type': 'multipart/form-data; boundary=183efc470a9645c4af49e8b12f917d14', 'Cray-Tenant-Name': 'vcluster-blue'}, 'verify': False}
uai_age = "0m"
uai_connect_string = "ssh vers@10.102.162.162"
uai_host = "ncn-w006"
uai_img = "artifactory.algol60.net/csm-docker/stable/cray-uai-sles15sp3:1.8.1"
uai_ip = "10.102.162.162"
uai_msg = "ContainerCreating"
uai_name = "uai-vers-00422161"
uai_status = "Waiting"
username = "vers"

[uai_portmap]
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
