### PR TITLE
CASMCMS-8905: Remove BOS v2 sessions update commands; add test to verify same

### DIFF
--- a/cray/modules/bos/cli.py
+++ b/cray/modules/bos/cli.py
@@ -1,7 +1,7 @@
 #
 #  MIT License
 #
-#  (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+#  (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a
 #  copy of this software and associated documentation files (the "Software"),
@@ -37,6 +37,9 @@ SWAGGER_OPTS = {
 }
 
 cli = generate(__file__, swagger_opts=SWAGGER_OPTS)
+
+# Update v2 sessions should only be in the API -- not intended for CLI use
+del cli.commands['v2'].commands['sessions'].commands['update']
 
 # Place the v2 commands at the 'cray bos' level of the cli
 CURRENT_VERSION = 'v2'

--- a/cray/tests/test_modules/test_bos.py
+++ b/cray/tests/test_modules/test_bos.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -270,6 +270,33 @@ def test_cray_bos_session_create(cli_runner, rest_mock):
             'templateUuid': 'foo', 'operation': 'boot',
         }, data['body']
     )
+
+
+def test_cray_bos_sessions_base(cli_runner, rest_mock):
+    """ Test cray bos session base command """
+    runner, cli, _ = cli_runner
+    result = runner.invoke(cli, ['bos', 'sessions'])
+    assert result.exit_code == 0
+
+    outputs = ['Groups:', 'status', 'Commands:', 'create', 'delete',
+               'describe', 'list']
+    for txt in outputs:
+        assert txt in result.output
+    assert 'update' not in result.output
+
+
+def test_cray_bos_v2_sessions_base(cli_runner, rest_mock):
+    """ Test cray bos v2 session base command """
+    runner, cli, _ = cli_runner
+    result = runner.invoke(cli, ['bos', 'v2', 'sessions'])
+    assert result.exit_code == 0
+
+    outputs = ['Groups:', 'status', 'Commands:', 'create', 'delete',
+               'describe', 'list']
+    for txt in outputs:
+        assert txt in result.output
+    assert 'update' not in result.output
+
 
 # pylint: disable=redefined-outer-name
 def test_cray_bos_v2_sessions_create(cli_runner, rest_mock):


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [CASMCMS-8905](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8905)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

The ability to update a BOS v2 session is really intended for use only by the BOS service itself. Thus, it should not be in the CLI. This PR removes it.

I tested the updated CLI on mug and verified that the v2 sessions update option is gone, but the other options all remain.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

It is riskier not to fix this, because if someone DOES start modifying BOS v2 sessions via the CLI, the results will almost certainly not be what they want.

-->
