### PR TITLE
CASMCMS-8795 - add remote build node api to IMS.

### DIFF
--- a/cray/modules/ims/openapi.yaml
+++ b/cray/modules/ims/openapi.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/cray/modules/ims/openapi.yaml
+++ b/cray/modules/ims/openapi.yaml
@@ -66,6 +66,17 @@ info:
         artifact repository. Recipes themselves define how an image is to be created, including the
         RPMs that will be installed, the RPM repositories to use, etc.
 
+      ### /remote-build-nodes
+
+        Manage the set of nodes set up for running remote jobs. These are jobs that are
+        run on nodes outside of the set of Kubernetes worker nodes. They can be used to
+        offload work from the worker nodes, or match the archetecture of the images
+        being created or customized.
+
+        The remote node must be fully configured and booted into the 'remote-node-image'
+        by the site-admin prior to registration in IMS. It will be tested prior to job
+        launch and if it is not accessible or correctly configured it will not be used.
+
     ## Workflows
 
       There are two main workflows using the IMS - image creation and image customization.
@@ -521,6 +532,99 @@ paths:
       responses:
         '204':
           description: Public Key record deleted successfully
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v3/remote-build-nodes:
+    get:
+      summary: List remote build nodes
+      operationId: get_all_v3_remote_build_nodes
+      tags:
+        - remote build node
+        - v3
+      description: Retrieve a list of remote build nodes that are registered with IMS.
+      responses:
+        '200':
+          description: A collection of remote build nodes
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/RemoteBuildNodeRecord'
+                type: array
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      summary: Create a new remote built node record
+      operationId: post_v3_remote_build_node
+      tags:
+        - remote build node
+        - v3
+      description: Create a new remote build node record. Updated by administrator to allow them to run jobs on a remote build node.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemoteBuildNodeRecord'
+        description: Remote build node record to create
+        required: true
+      responses:
+        '201':
+          description: New RemoteBuildNode
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteBuildNodeRecord'
+        '400':
+          $ref: '#/components/responses/NoInputProvided'
+        '422':
+          $ref: '#/components/responses/InvalidInputData'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      summary: Delete all RemoteBuildNodeRecords
+      operationId: delete_all_v3_remote_build_nodes
+      tags:
+        - remote build node
+        - v3
+      description: Delete all remote build node records.
+      responses:
+        '204':
+          description: Remote build node records deleted successfully
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/v3/remote-build-nodes/{remote_build_node_xname}':
+    parameters:
+      - $ref: '#/components/parameters/remote_build_node_xname'
+    get:
+      summary: Retrieve a remote build node by remote_build_node_xname
+      operationId: get_v3_remote_build_node
+      tags:
+        - remote build node
+        - v3
+      description: Retrieve a remote build node by remote_build_node_xname
+      responses:
+        '200':
+          description: A remote build node record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteBuildNodeRecord'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      summary: Delete remote build node by remote_build_node_xname
+      operationId: delete_v3_remote_build_node
+      tags:
+        - remote build node
+        - v3
+      description: Delete a RemoteBuildNodeRecord by Xname.
+      responses:
+        '204':
+          description: Remote build node record deleted successfully
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -1640,6 +1744,10 @@ paths:
     $ref: "#/paths/~1v2~1public-keys"
   /public-keys/{public_key_id}:
     $ref: "#/paths/~1v2~1public-keys~1{public_key_id}"
+  /remote-build-nodes:
+    $ref: "#/paths/~1v3~1remote-build-nodes"
+  /remote-build-nodes/{remote_build_node_xname}:
+    $ref: "#/paths/~1v3~1remote-build-nodes~1{remote_build_node_xname}"
   /jobs:
     $ref: "#/paths/~1v2~1jobs"
   /jobs/{job_id}:
@@ -1742,6 +1850,14 @@ components:
         type: string
         format: uuid
       example: bc6ec895-6ff5-4481-bd98-88ed4cd233e9
+    remote_build_node_xname:
+      description: The unique xname of a remote build node
+      in: path
+      name: remote_build_node_xname
+      required: true
+      schema:
+        type: string
+      example: x3000c1s10b1n0
     job_id:
       description: The unique ID of a job
       in: path
@@ -1943,6 +2059,17 @@ components:
             ssh-rsa AAAAB3NzaC1yc2EAAAADAQABA ...
             fa6hG9i2SzfY8L6vAVvSE7A2ILAsVruw1Zeiec2IWt
 
+          type: string
+          minLength: 1
+    RemoteBuildNodeRecord:
+      description: A Remote Build Node Record
+      type: object
+      required:
+        - xname
+      properties:
+        xname:
+          description: Xname of the remote build node
+          example: x3000c1s10b1n0
           type: string
           minLength: 1
     ArtifactLinkRecord:

--- a/cray/modules/ims/swagger3.json
+++ b/cray/modules/ims/swagger3.json
@@ -1,7 +1,7 @@
 {
     "openapi": "3.0.2",
     "info": {
-        "description": "The Image Management Service (IMS) creates and customizes boot images which run on compute nodes. A boot image consists of multiple image artifacts including the root file system (rootfs), kernel, and initrd. There are optionally additional artifacts such as debug symbols, etc.\nIMS uses the open source Kiwi-NG tool to build image roots from compressed Kiwi image descriptions (recipes). Kiwi-NG is able to build images based on a variety of different Linux distributions, specifically SUSE, RHEL, and their derivatives.\nA user may choose to use the provided recipes or customize Kiwi recipes to define the image to be built.\nIMS creates and customizes existing boot images and maintains metadata about the images and related artifacts. IMS accesses and stores the recipes, images, and related artifacts in the artifact repository.\n## Resources\n\n  ### /images\n\n    Manipulate ImageRecords, which relate multiple image artifact records together.\n\n  ### /jobs\n\n    Initiate image creation or customization.  It creates the image which it uploads to the\n    artifact repository, and maintains associated metadata in IMS for subsequent access. It\n    also customizes a pre-existing image.\n\n  ### /public-keys\n\n    Manage the public keys which enable SSH access. Public-keys are created and uploaded by the\n    administrator to allow access to SSH shells provided by IMS during image creation and\n    customization.\n\n  ### /recipes\n\n    Manipulate the RecipeRecord metadata about the Kiwi-NG recipes which are stored in the\n    artifact repository. Recipes themselves define how an image is to be created, including the\n    RPMs that will be installed, the RPM repositories to use, etc.\n\n## Workflows\n\n  There are two main workflows using the IMS - image creation and image customization.\n  The IMS /jobs endpoint directs the creation of a new image, or the customization of an\n  existing image, depending on the POST /jobs request job_type body parameter.\n\n  ### Add a New Recipe\n\n    #### GET /recipes\n\n      Obtain list of existing recipes which are registered with IMS.\n\n    #### Upload recipe using CLI\n\n      Upload a new recipe to the artifact repository using the cray artifacts command, if necessary.\n      Refer to Administrator's Guide for instructions.\n\n    #### POST /recipes\n\n      Register new recipe with IMS.\n\n  ### Manage Public Keys\n\n    #### GET /public-keys\n\n      Obtain list of available public-keys.\n\n    #### POST /public-keys\n\n      Add a new public-key.\n\n  ### Create a New Image\n\n    #### GET /public-keys\n\n      Get a list of available keys.\n\n    #### GET /recipes\n\n      Get recipe ID.\n\n    #### POST /jobs\n\n      Use Kiwi-NG to create a new IMS image and image artifacts from a recipe. Specify job_type\n      \"create\" in JobRecord. Request body parameters supply the recipe ID and public key ID.\n      Upon success, the artifact repository contains the new image and the image artifacts,\n      IMS contains a new ImageRecord with metadata for the new image. During the creation\n      process, IMS may create an SSH shell for administrator interaction with the image for\n      debugging, if necessary.  (enable_debug = true in JobRecord)\n\n  ### Modify an Image\n\n    #### GET /public-keys\n\n      Get a list of available keys.\n\n    #### GET /images\n\n      Obtain a list of available images registered in IMS.\n\n    #### POST /jobs\n\n      To create a modified version of an existing IMS image, specify job_type \"customize\".\n      Specify the IMS ID of the existing image, and public key.  This request creates a copy of\n      the existing image, and then an interactive SSH shell in which to modify the copy of the\n      image. Upon success, the artifact repository contains the original image and a modified\n      version of it. IMS contains a new ImageRecord with metadata for the modified image. The\n      original image is still intact.  A user may want to install additional software, install\n      licenses, change the timezone, add mount points, etc.\n",
+        "description": "The Image Management Service (IMS) creates and customizes boot images which run on compute nodes. A boot image consists of multiple image artifacts including the root file system (rootfs), kernel, and initrd. There are optionally additional artifacts such as debug symbols, etc.\nIMS uses the open source Kiwi-NG tool to build image roots from compressed Kiwi image descriptions (recipes). Kiwi-NG is able to build images based on a variety of different Linux distributions, specifically SUSE, RHEL, and their derivatives.\nA user may choose to use the provided recipes or customize Kiwi recipes to define the image to be built.\nIMS creates and customizes existing boot images and maintains metadata about the images and related artifacts. IMS accesses and stores the recipes, images, and related artifacts in the artifact repository.\n## Resources\n\n  ### /images\n\n    Manipulate ImageRecords, which relate multiple image artifact records together.\n\n  ### /jobs\n\n    Initiate image creation or customization.  It creates the image which it uploads to the\n    artifact repository, and maintains associated metadata in IMS for subsequent access. It\n    also customizes a pre-existing image.\n\n  ### /public-keys\n\n    Manage the public keys which enable SSH access. Public-keys are created and uploaded by the\n    administrator to allow access to SSH shells provided by IMS during image creation and\n    customization.\n\n  ### /recipes\n\n    Manipulate the RecipeRecord metadata about the Kiwi-NG recipes which are stored in the\n    artifact repository. Recipes themselves define how an image is to be created, including the\n    RPMs that will be installed, the RPM repositories to use, etc.\n\n  ### /remote-build-nodes\n\n    Manage the set of nodes set up for running remote jobs. These are jobs that are\n    run on nodes outside of the set of Kubernetes worker nodes. They can be used to\n    offload work from the worker nodes, or match the archetecture of the images\n    being created or customized.\n\n    The remote node must be fully configured and booted into the 'remote-node-image'\n    by the site-admin prior to registration in IMS. It will be tested prior to job\n    launch and if it is not accessible or correctly configured it will not be used.\n\n## Workflows\n\n  There are two main workflows using the IMS - image creation and image customization.\n  The IMS /jobs endpoint directs the creation of a new image, or the customization of an\n  existing image, depending on the POST /jobs request job_type body parameter.\n\n  ### Add a New Recipe\n\n    #### GET /recipes\n\n      Obtain list of existing recipes which are registered with IMS.\n\n    #### Upload recipe using CLI\n\n      Upload a new recipe to the artifact repository using the cray artifacts command, if necessary.\n      Refer to Administrator's Guide for instructions.\n\n    #### POST /recipes\n\n      Register new recipe with IMS.\n\n  ### Manage Public Keys\n\n    #### GET /public-keys\n\n      Obtain list of available public-keys.\n\n    #### POST /public-keys\n\n      Add a new public-key.\n\n  ### Create a New Image\n\n    #### GET /public-keys\n\n      Get a list of available keys.\n\n    #### GET /recipes\n\n      Get recipe ID.\n\n    #### POST /jobs\n\n      Use Kiwi-NG to create a new IMS image and image artifacts from a recipe. Specify job_type\n      \"create\" in JobRecord. Request body parameters supply the recipe ID and public key ID.\n      Upon success, the artifact repository contains the new image and the image artifacts,\n      IMS contains a new ImageRecord with metadata for the new image. During the creation\n      process, IMS may create an SSH shell for administrator interaction with the image for\n      debugging, if necessary.  (enable_debug = true in JobRecord)\n\n  ### Modify an Image\n\n    #### GET /public-keys\n\n      Get a list of available keys.\n\n    #### GET /images\n\n      Obtain a list of available images registered in IMS.\n\n    #### POST /jobs\n\n      To create a modified version of an existing IMS image, specify job_type \"customize\".\n      Specify the IMS ID of the existing image, and public key.  This request creates a copy of\n      the existing image, and then an interactive SSH shell in which to modify the copy of the\n      image. Upon success, the artifact repository contains the original image and a modified\n      version of it. IMS contains a new ImageRecord with metadata for the modified image. The\n      original image is still intact.  A user may want to install additional software, install\n      licenses, change the timezone, add mount points, etc.\n",
         "version": "0.0.0-imsserv",
         "title": "Image Management Service",
         "license": {
@@ -2954,6 +2954,544 @@
                 "responses": {
                     "204": {
                         "description": "Public Key record deleted successfully"
+                    },
+                    "404": {
+                        "description": "Requested resource does not exist. Re-run request with valid ID.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "An internal error occurred. Re-running the request may or may not succeed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v3/remote-build-nodes": {
+            "get": {
+                "summary": "List remote build nodes",
+                "operationId": "get_all_v3_remote_build_nodes",
+                "tags": [
+                    "remote build node",
+                    "v3"
+                ],
+                "description": "Retrieve a list of remote build nodes that are registered with IMS.",
+                "responses": {
+                    "200": {
+                        "description": "A collection of remote build nodes",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "description": "A Remote Build Node Record",
+                                        "type": "object",
+                                        "required": [
+                                            "xname"
+                                        ],
+                                        "properties": {
+                                            "xname": {
+                                                "description": "Xname of the remote build node",
+                                                "example": "x3000c1s10b1n0",
+                                                "type": "string",
+                                                "minLength": 1
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "An internal error occurred. Re-running the request may or may not succeed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "summary": "Create a new remote built node record",
+                "operationId": "post_v3_remote_build_node",
+                "tags": [
+                    "remote build node",
+                    "v3"
+                ],
+                "description": "Create a new remote build node record. Updated by administrator to allow them to run jobs on a remote build node.",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "description": "A Remote Build Node Record",
+                                "type": "object",
+                                "required": [
+                                    "xname"
+                                ],
+                                "properties": {
+                                    "xname": {
+                                        "description": "Xname of the remote build node",
+                                        "example": "x3000c1s10b1n0",
+                                        "type": "string",
+                                        "minLength": 1
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "description": "Remote build node record to create",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "New RemoteBuildNode",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "A Remote Build Node Record",
+                                    "type": "object",
+                                    "required": [
+                                        "xname"
+                                    ],
+                                    "properties": {
+                                        "xname": {
+                                            "description": "Xname of the remote build node",
+                                            "example": "x3000c1s10b1n0",
+                                            "type": "string",
+                                            "minLength": 1
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "No input provided. Determine the specific information that is missing or invalid and then re-run the request with valid information.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "An internal error occurred. Re-running the request may or may not succeed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete all RemoteBuildNodeRecords",
+                "operationId": "delete_all_v3_remote_build_nodes",
+                "tags": [
+                    "remote build node",
+                    "v3"
+                ],
+                "description": "Delete all remote build node records.",
+                "responses": {
+                    "204": {
+                        "description": "Remote build node records deleted successfully"
+                    },
+                    "500": {
+                        "description": "An internal error occurred. Re-running the request may or may not succeed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v3/remote-build-nodes/{remote_build_node_xname}": {
+            "parameters": [
+                {
+                    "description": "The unique xname of a remote build node",
+                    "in": "path",
+                    "name": "remote_build_node_xname",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "example": "x3000c1s10b1n0"
+                }
+            ],
+            "get": {
+                "summary": "Retrieve a remote build node by remote_build_node_xname",
+                "operationId": "get_v3_remote_build_node",
+                "tags": [
+                    "remote build node",
+                    "v3"
+                ],
+                "description": "Retrieve a remote build node by remote_build_node_xname",
+                "responses": {
+                    "200": {
+                        "description": "A remote build node record",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "A Remote Build Node Record",
+                                    "type": "object",
+                                    "required": [
+                                        "xname"
+                                    ],
+                                    "properties": {
+                                        "xname": {
+                                            "description": "Xname of the remote build node",
+                                            "example": "x3000c1s10b1n0",
+                                            "type": "string",
+                                            "minLength": 1
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Requested resource does not exist. Re-run request with valid ID.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "An internal error occurred. Re-running the request may or may not succeed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete remote build node by remote_build_node_xname",
+                "operationId": "delete_v3_remote_build_node",
+                "tags": [
+                    "remote build node",
+                    "v3"
+                ],
+                "description": "Delete a RemoteBuildNodeRecord by Xname.",
+                "responses": {
+                    "204": {
+                        "description": "Remote build node record deleted successfully"
                     },
                     "404": {
                         "description": "Requested resource does not exist. Re-run request with valid ID.",
@@ -15346,6 +15884,544 @@
                 }
             }
         },
+        "/remote-build-nodes": {
+            "get": {
+                "summary": "List remote build nodes",
+                "operationId": "get_all_v3_remote_build_nodes",
+                "tags": [
+                    "remote build node",
+                    "v3"
+                ],
+                "description": "Retrieve a list of remote build nodes that are registered with IMS.",
+                "responses": {
+                    "200": {
+                        "description": "A collection of remote build nodes",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "description": "A Remote Build Node Record",
+                                        "type": "object",
+                                        "required": [
+                                            "xname"
+                                        ],
+                                        "properties": {
+                                            "xname": {
+                                                "description": "Xname of the remote build node",
+                                                "example": "x3000c1s10b1n0",
+                                                "type": "string",
+                                                "minLength": 1
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "An internal error occurred. Re-running the request may or may not succeed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "summary": "Create a new remote built node record",
+                "operationId": "post_v3_remote_build_node",
+                "tags": [
+                    "remote build node",
+                    "v3"
+                ],
+                "description": "Create a new remote build node record. Updated by administrator to allow them to run jobs on a remote build node.",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "description": "A Remote Build Node Record",
+                                "type": "object",
+                                "required": [
+                                    "xname"
+                                ],
+                                "properties": {
+                                    "xname": {
+                                        "description": "Xname of the remote build node",
+                                        "example": "x3000c1s10b1n0",
+                                        "type": "string",
+                                        "minLength": 1
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "description": "Remote build node record to create",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "New RemoteBuildNode",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "A Remote Build Node Record",
+                                    "type": "object",
+                                    "required": [
+                                        "xname"
+                                    ],
+                                    "properties": {
+                                        "xname": {
+                                            "description": "Xname of the remote build node",
+                                            "example": "x3000c1s10b1n0",
+                                            "type": "string",
+                                            "minLength": 1
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "No input provided. Determine the specific information that is missing or invalid and then re-run the request with valid information.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "An internal error occurred. Re-running the request may or may not succeed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete all RemoteBuildNodeRecords",
+                "operationId": "delete_all_v3_remote_build_nodes",
+                "tags": [
+                    "remote build node",
+                    "v3"
+                ],
+                "description": "Delete all remote build node records.",
+                "responses": {
+                    "204": {
+                        "description": "Remote build node records deleted successfully"
+                    },
+                    "500": {
+                        "description": "An internal error occurred. Re-running the request may or may not succeed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/remote-build-nodes/{remote_build_node_xname}": {
+            "parameters": [
+                {
+                    "description": "The unique xname of a remote build node",
+                    "in": "path",
+                    "name": "remote_build_node_xname",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "example": "x3000c1s10b1n0"
+                }
+            ],
+            "get": {
+                "summary": "Retrieve a remote build node by remote_build_node_xname",
+                "operationId": "get_v3_remote_build_node",
+                "tags": [
+                    "remote build node",
+                    "v3"
+                ],
+                "description": "Retrieve a remote build node by remote_build_node_xname",
+                "responses": {
+                    "200": {
+                        "description": "A remote build node record",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "A Remote Build Node Record",
+                                    "type": "object",
+                                    "required": [
+                                        "xname"
+                                    ],
+                                    "properties": {
+                                        "xname": {
+                                            "description": "Xname of the remote build node",
+                                            "example": "x3000c1s10b1n0",
+                                            "type": "string",
+                                            "minLength": 1
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Requested resource does not exist. Re-run request with valid ID.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "An internal error occurred. Re-running the request may or may not succeed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete remote build node by remote_build_node_xname",
+                "operationId": "delete_v3_remote_build_node",
+                "tags": [
+                    "remote build node",
+                    "v3"
+                ],
+                "description": "Delete a RemoteBuildNodeRecord by Xname.",
+                "responses": {
+                    "204": {
+                        "description": "Remote build node record deleted successfully"
+                    },
+                    "404": {
+                        "description": "Requested resource does not exist. Re-run request with valid ID.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "An internal error occurred. Re-running the request may or may not succeed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the problem. Focus on helping correct the problem, rather than giving debugging information.",
+                                            "type": "string"
+                                        },
+                                        "errors": {
+                                            "description": "An object denoting field-specific errors. Only present on error responses when field input is specified for the request.",
+                                            "type": "object"
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of the problem",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "example": 400,
+                                            "type": "integer"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by occurrence.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "default": "about:blank",
+                                            "description": "Relative URI reference to the type of problem which includes human-readable documentation.",
+                                            "format": "uri",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/jobs": {
             "get": {
                 "summary": "Retrieve a list of JobRecords that are registered with IMS",
@@ -17215,6 +18291,16 @@
                 },
                 "example": "bc6ec895-6ff5-4481-bd98-88ed4cd233e9"
             },
+            "remote_build_node_xname": {
+                "description": "The unique xname of a remote build node",
+                "in": "path",
+                "name": "remote_build_node_xname",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                },
+                "example": "x3000c1s10b1n0"
+            },
             "job_id": {
                 "description": "The unique ID of a job",
                 "in": "path",
@@ -17644,6 +18730,21 @@
                     "public_key": {
                         "description": "The raw public key",
                         "example": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABA ... fa6hG9i2SzfY8L6vAVvSE7A2ILAsVruw1Zeiec2IWt",
+                        "type": "string",
+                        "minLength": 1
+                    }
+                }
+            },
+            "RemoteBuildNodeRecord": {
+                "description": "A Remote Build Node Record",
+                "type": "object",
+                "required": [
+                    "xname"
+                ],
+                "properties": {
+                    "xname": {
+                        "description": "Xname of the remote build node",
+                        "example": "x3000c1s10b1n0",
                         "type": "string",
                         "minLength": 1
                     }

--- a/cray/tests/test_modules/test_ims.py
+++ b/cray/tests/test_modules/test_ims.py
@@ -59,7 +59,8 @@ def test_cray_ims_base(cli_runner, rest_mock):
         "public-keys",
         "recipes",
         "images",
-        "jobs"
+        "jobs",
+        "remote-build-nodes"
     ]
 
     compare_output(outputs, result.output)
@@ -173,6 +174,92 @@ def test_cray_ims_public_keys_create_missing_required(cli_runner, rest_mock):
     )
     assert result.exit_code == 2
     assert '--public-key' in result.output
+
+def test_cray_ims_remote_build_nodes_base(cli_runner, rest_mock):
+    """ Test cray ims remote-build-nodes base command """
+    runner, cli, _ = cli_runner
+    result = runner.invoke(cli, ['ims', 'remote-build-nodes'])
+    assert result.exit_code == 0
+
+    outputs = [
+        "create",
+        "delete",
+        "deleteall",
+        "describe",
+        "list",
+    ]
+
+    compare_output(outputs, result.output)
+
+
+def test_cray_ims_remote_build_nodes_delete(cli_runner, rest_mock):
+    """ Test cray ims public_keys delete ... """
+    runner, cli, config = cli_runner
+    result = runner.invoke(cli, ['ims', 'remote-build-nodes', 'delete', 'foo'])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data['method'] == 'DELETE'
+    assert data['url'] == f'{config["default"]["hostname"]}/apis/ims/v3/remote-build-nodes/foo'
+
+
+def test_cray_ims_remote_build_nodes_delete_all(cli_runner, rest_mock):
+    """ Test cray ims public_keys delete ... """
+    runner, cli, config = cli_runner
+    result = runner.invoke(cli, ['ims', 'remote-build-nodes', 'deleteall'])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data['method'] == 'DELETE'
+    assert data['url'] == f'{config["default"]["hostname"]}/apis/ims/v3/remote-build-nodes'
+
+
+def test_cray_ims_remote_build_nodes_list(cli_runner, rest_mock):
+    """ Test cray ims public_keys list """
+    runner, cli, config = cli_runner
+    result = runner.invoke(cli, ['ims', 'remote-build-nodes', 'list'])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data['method'] == 'GET'
+    assert data['url'] == f'{config["default"]["hostname"]}/apis/ims/v3/remote-build-nodes'
+
+
+def test_cray_ims_remote_build_nodes_describe(cli_runner, rest_mock):
+    """ Test cray ims public_keys describe """
+    runner, cli, config = cli_runner
+    result = runner.invoke(cli, ['ims', 'remote-build-nodes', 'describe', 'foo'])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data['method'] == 'GET'
+    assert data['url'] == f'{config["default"]["hostname"]}/apis/ims/v3/remote-build-nodes/foo'
+
+
+def test_cray_ims_remote_build_nodes_create(cli_runner, rest_mock):
+    """ Test cray ims public_keys create ... happy path """
+    runner, cli, config = cli_runner
+    result = runner.invoke(
+        cli,
+        ['ims', 'remote-build-nodes', 'create', '--xname', 'foo']
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data['method'] == 'POST'
+    assert data['url'] == f'{config["default"]["hostname"]}/apis/ims/v3/remote-build-nodes'
+    assert data['body'] == {
+        'xname': 'foo'
+    }
+
+
+def test_cray_ims_remote_build_nodes_create_missing_required(cli_runner, rest_mock):
+    """Test cray ims public_keys create ... when a required parameter is
+    missing
+
+    """
+    runner, cli, _ = cli_runner
+    result = runner.invoke(
+        cli,
+        ['ims', 'remote-build-nodes', 'create']
+    )
+    assert result.exit_code == 2
+    assert '--xname' in result.output
 
 
 def test_cray_ims_deleted_public_keys_base(cli_runner, rest_mock):

--- a/cray/tests/test_modules/test_ims.py
+++ b/cray/tests/test_modules/test_ims.py
@@ -1,7 +1,7 @@
 #
 #  MIT License
 #
-#  (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+#  (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a
 #  copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
### Summary and Scope

CASMCMS-8795 - update the cray cli to include the new ims api to add/remove/list remote build nodes.

#### Issue Type

- RFE Pull Request
https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8795

### Prerequisites
- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

I have tested this on Mug, Tyr, and Baldar. This interface was required for testing the new features on these systems.
 
### Idempotency

If this version of the cray cli is installed on a system without the correct version of IMS that contains the new remote build nodes feature, that api will not work, but the rest of the api works exactly as it did before.
 
### Risks and Mitigations

This is a low risk, as the other IMS api calls work independently from the new features.
