### PR TITLE
Added workaround for the conflict in --hostname for craycli v0.82

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.swp
 .bash*
 .config
+.python-version
+.idea
 dist
 build
 parts

--- a/cray/modules/hsm/swagger_v2.yaml
+++ b/cray/modules/hsm/swagger_v2.yaml
@@ -1419,6 +1419,9 @@ paths:
             - NodeEnclosure
             - NodeEnclosurePowerSupply
             - HSNBoard
+            - MgmtSwitch
+            - MgmtHLSwitch
+            - CDUMgmtSwitch
             - Node
             - Processor
             - Drive
@@ -4674,7 +4677,7 @@ paths:
           schema:
             $ref: '#/definitions/Subscriptions_SCNPostSubscription'
       responses:
-        "200":
+        "204":
           description: Success. The subscription has been overwritten.
         "400":
           description: >-
@@ -7015,6 +7018,30 @@ definitions:
           $ref: '#/definitions/HWInvByLocHSNBoard'
         readOnly: true
         type: array
+      MgmtSwitches:
+        description: >-
+          All appropriate components with HMS type 'MgmtSwitch' given
+          Target component/partition and query type.
+        items:
+          $ref: '#/definitions/HWInvByLocMgmtSwitch'
+        readOnly: true
+        type: array
+      MgmtHLSwitches:
+        description: >-
+          All appropriate components with HMS type 'MgmtHLSwitch' given
+          Target component/partition and query type.
+        items:
+          $ref: '#/definitions/HWInvByLocMgmtHLSwitch'
+        readOnly: true
+        type: array
+      CDUMgmtSwitches:
+        description: >-
+          All appropriate components with HMS type 'CDUMgmtSwitch' given
+          Target component/partition and query type.
+        items:
+          $ref: '#/definitions/HWInvByLocCDUMgmtSwitch'
+        readOnly: true
+        type: array
       Nodes:
         description: >-
           All appropriate components with HMS type 'Node' given Target
@@ -7168,6 +7195,9 @@ definitions:
           - HWInvByLocRouterModule
           - HWInvByLocNodeEnclosure
           - HWInvByLocHSNBoard
+          - HWInvByLocMgmtSwitch
+          - HWInvByLocMgmtHLSwitch
+          - HWInvByLocCDUMgmtSwitch
           - HWInvByLocNode
           - HWInvByLocProcessor
           - HWInvByLocNodeAccel
@@ -7361,6 +7391,45 @@ definitions:
       - type: object
         properties:
           HSNBoardLocationInfo:
+            $ref: '#/definitions/HWInventory.1.0.0_RedfishChassisLocationInfo'
+    type: object
+  HWInvByLocMgmtSwitch:
+    description: >-
+      This is a subtype of HWInventoryByLocation for HMSType MgmtSwitch.
+      It represents a management switch.  It is selected via the
+      'discriminator: HWInventoryByLocationType' of HWInventoryByLocation
+      when HWInventoryByLocationType is 'HWInvByLocMgmtSwitch'.
+    allOf:
+      - $ref: '#/definitions/HWInventory.1.0.0_HWInventoryByLocation'
+      - type: object
+        properties:
+          MgmtSwitchLocationInfo:
+            $ref: '#/definitions/HWInventory.1.0.0_RedfishChassisLocationInfo'
+    type: object
+  HWInvByLocMgmtHLSwitch:
+    description: >-
+      This is a subtype of HWInventoryByLocation for HMSType MgmtHLSwitch.
+      It represents a high level management switch.  It is selected via the
+      'discriminator: HWInventoryByLocationType' of HWInventoryByLocation
+      when HWInventoryByLocationType is 'HWInvByLocMgmtHLSwitch'.
+    allOf:
+      - $ref: '#/definitions/HWInventory.1.0.0_HWInventoryByLocation'
+      - type: object
+        properties:
+          MgmtHLSwitchLocationInfo:
+            $ref: '#/definitions/HWInventory.1.0.0_RedfishChassisLocationInfo'
+    type: object
+  HWInvByLocCDUMgmtSwitch:
+    description: >-
+      This is a subtype of HWInventoryByLocation for HMSType CDUMgmtSwitch.
+      It represents a CDU management switch.  It is selected via the
+      'discriminator: HWInventoryByLocationType' of HWInventoryByLocation
+      when HWInventoryByLocationType is 'HWInvByLocCDUMgmtSwitch'.
+    allOf:
+      - $ref: '#/definitions/HWInventory.1.0.0_HWInventoryByLocation'
+      - type: object
+        properties:
+          CDUMgmtSwitchLocationInfo:
             $ref: '#/definitions/HWInventory.1.0.0_RedfishChassisLocationInfo'
     type: object
   HWInvByLocNode:
@@ -8403,6 +8472,9 @@ definitions:
           - HWInvByFRURouterModule
           - HWInvByFRUNodeEnclosure
           - HWInvByFRUHSNBoard
+          - HWInvByFRUMgmtSwitch
+          - HWInvByFRUMgmtHLSwitch
+          - HWInvByFRUCDUMgmtSwitch
           - HWInvByFRUNode
           - HWInvByFRUProcessor
           - HWInvByFRUNodeAccel
@@ -8516,6 +8588,45 @@ definitions:
       - type: object
         properties:
           HSNBoardFRUInfo:
+            $ref: '#/definitions/HWInventory.1.0.0_RedfishChassisFRUInfo'
+    type: object
+  HWInvByFRUMgmtSwitch:
+    description: >-
+      This is a subtype of HWInventoryByFRU for HMSType MgmtSwitch.
+      It represents a management switch.  It is selected via the
+      'discriminator: HWInventoryByFRUType' of HWInventoryByFRU when
+      HWInventoryByFRUType is 'HWInvByFRUMgmtSwitch'.
+    allOf:
+      - $ref: '#/definitions/HWInventory.1.0.0_HWInventoryByFRU'
+      - type: object
+        properties:
+          MgmtSwitchFRUInfo:
+            $ref: '#/definitions/HWInventory.1.0.0_RedfishChassisFRUInfo'
+    type: object
+  HWInvByFRUMgmtHLSwitch:
+    description: >-
+      This is a subtype of HWInventoryByFRU for HMSType MgmtHLSwitch.
+      It represents a high level management switch.  It is selected via the
+      'discriminator: HWInventoryByFRUType' of HWInventoryByFRU when
+      HWInventoryByFRUType is 'HWInvByFRUMgmtHLSwitch'.
+    allOf:
+      - $ref: '#/definitions/HWInventory.1.0.0_HWInventoryByFRU'
+      - type: object
+        properties:
+          MgmtHLSwitchFRUInfo:
+            $ref: '#/definitions/HWInventory.1.0.0_RedfishChassisFRUInfo'
+    type: object
+  HWInvByFRUCDUMgmtSwitch:
+    description: >-
+      This is a subtype of HWInventoryByFRU for HMSType CDUMgmtSwitch.
+      It represents a CDU management switch.  It is selected via the
+      'discriminator: HWInventoryByFRUType' of HWInventoryByFRU when
+      HWInventoryByFRUType is 'HWInvByFRUCDUMgmtSwitch'.
+    allOf:
+      - $ref: '#/definitions/HWInventory.1.0.0_HWInventoryByFRU'
+      - type: object
+        properties:
+          CDUMgmtSwitchFRUInfo:
             $ref: '#/definitions/HWInventory.1.0.0_RedfishChassisFRUInfo'
     type: object
   HWInvByFRUNode:
@@ -11679,6 +11790,9 @@ definitions:
       - NodeEnclosure
       - NodeEnclosurePowerSupply
       - HSNBoard
+      - MgmtSwitch
+      - MgmtHLSwitch
+      - CDUMgmtSwitch
       - Node
       - Processor
       - Drive
@@ -11964,6 +12078,9 @@ parameters:
       - NodeEnclosure
       - NodeEnclosurePowerSupply
       - HSNBoard
+      - MgmtSwitch
+      - MgmtHLSwitch
+      - CDUMgmtSwitch
       - Node
       - Processor
       - Drive
@@ -12080,7 +12197,7 @@ parameters:
       - X86
       - ARM
       - Other
-      - Unknown
+      - UNKNOWN
   compClassParam:
     name: class
     in: query


### PR DESCRIPTION
### Summary and Scope

Added a workaround so that the global `--hostname` value (from the config file) does not get used in in `cray hsm redfishEndpoints update` and `cray hsm redfishEndpoints create`. These calls also have a `--hostname` option.

This PR also updates the hsm swagger file.

- Fixes: [CASMHMS-6154](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6154)

#### Issue Type

- Bugfix Pull Request

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
  
### Risks and Mitigations