### PR TITLE
IMS: Add image tagging support

### DIFF
--- a/cray/modules/ims/openapi.yaml
+++ b/cray/modules/ims/openapi.yaml
@@ -2245,6 +2245,55 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RecipeKeyValuePair'
+    ImageMetadataAnnotationKeyValuePair:
+      description: Key/value pair used to further define an Image
+      type: object
+      required:
+        - key
+        - value
+      properties:
+        key:
+          description: Template variable to associate with the IMS image
+          example: includes_additional_packages
+          type: string
+        value:
+          description: Value variable to associate with the IMS image
+          example: "foo,bar,baz"
+          type: string
+    ImagePatchRecord:
+      description: Values used to update an existing IMS Image Record
+      type: object
+      properties:
+        link:
+          $ref: '#/components/schemas/ArtifactLinkRecord'
+        arch:
+          description: Target architecture for the recipe.
+          example: aarch64
+          enum:
+            - aarch64
+            - x86_64
+          type: string
+        metadata:
+          description: An object which indicates a number of annotation patch operations relating to image tags.
+          type: object
+          required:
+            - operation
+            - key
+          properties:
+            operation:
+              description: How to update a given key within the context of a patch operation
+              type: string
+              enum:
+                - set
+                - remove
+            key:
+              description: The key to update for a given image
+              type: string
+              example: includes_additional_packages
+            value:
+              description: The value to associate with a key during a patch operation
+              type: string
+              example: "vim,emacs,man"
     ImageRecord:
       description: An Image Record
       type: object
@@ -2277,6 +2326,11 @@ components:
             - aarch64
             - x86_64
           type: string
+        metadata:
+          description: An object of key/value associated with an Image
+          type: object
+          properties:
+            $ref: '#/components/schemas/ImageMetadataAnnotationKeyValuePair'
     DeletedImageRecord:
       description: A Deleted Image Record
       type: object
@@ -2316,19 +2370,11 @@ components:
             - aarch64
             - x86_64
           type: string
-    ImagePatchRecord:
-      description: Values to update an ImageRecord with
-      type: object
-      properties:
-        link:
-          $ref: '#/components/schemas/ArtifactLinkRecord'
-        arch:
-          description: Target architecture for the recipe.
-          example: aarch64
-          enum:
-            - aarch64
-            - x86_64
-          type: string
+        metadata:
+          description: List of key/value pairs to associate with an Image
+          type: object
+          properties:
+            $ref: '#/components/schemas/ImageMetadataAnnotationKeyValuePair'
     JobRecord:
       description: A Job Record
       type: object

--- a/cray/modules/ims/openapi.yaml
+++ b/cray/modules/ims/openapi.yaml
@@ -2312,11 +2312,8 @@ components:
             - x86_64
           type: string
         metadata:
-          description: Key/value pair used to further define an Image
+          description: User supplied annotations about an image
           type: object
-          required:
-            - key
-            - value
           properties:
             key:
               description: Template variable to associate with the IMS image

--- a/cray/modules/ims/openapi.yaml
+++ b/cray/modules/ims/openapi.yaml
@@ -2245,21 +2245,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RecipeKeyValuePair'
-    ImageMetadataAnnotationKeyValuePair:
-      description: Key/value pair used to further define an Image
-      type: object
-      required:
-        - key
-        - value
-      properties:
-        key:
-          description: Template variable to associate with the IMS image
-          example: includes_additional_packages
-          type: string
-        value:
-          description: Value variable to associate with the IMS image
-          example: "foo,bar,baz"
-          type: string
     ImagePatchRecord:
       description: Values used to update an existing IMS Image Record
       type: object
@@ -2327,10 +2312,20 @@ components:
             - x86_64
           type: string
         metadata:
-          description: An object of key/value associated with an Image
+          description: Key/value pair used to further define an Image
           type: object
+          required:
+            - key
+            - value
           properties:
-            $ref: '#/components/schemas/ImageMetadataAnnotationKeyValuePair'
+            key:
+              description: Template variable to associate with the IMS image
+              example: includes_additional_packages
+              type: string
+            value:
+              description: Value variable to associate with the IMS image
+              example: "foo,bar,baz"
+              type: string
     DeletedImageRecord:
       description: A Deleted Image Record
       type: object

--- a/cray/modules/ims/swagger3.json
+++ b/cray/modules/ims/swagger3.json
@@ -1429,12 +1429,8 @@
                                                 "type": "string"
                                             },
                                             "metadata": {
-                                                "description": "Key/value pair used to further define an Image",
+                                                "description": "User supplied annotations about an image",
                                                 "type": "object",
-                                                "required": [
-                                                    "key",
-                                                    "value"
-                                                ],
                                                 "properties": {
                                                     "key": {
                                                         "description": "Template variable to associate with the IMS image",
@@ -1571,12 +1567,8 @@
                                         "type": "string"
                                     },
                                     "metadata": {
-                                        "description": "Key/value pair used to further define an Image",
+                                        "description": "User supplied annotations about an image",
                                         "type": "object",
-                                        "required": [
-                                            "key",
-                                            "value"
-                                        ],
                                         "properties": {
                                             "key": {
                                                 "description": "Template variable to associate with the IMS image",
@@ -1664,12 +1656,8 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "Key/value pair used to further define an Image",
+                                            "description": "User supplied annotations about an image",
                                             "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
                                             "properties": {
                                                 "key": {
                                                     "description": "Template variable to associate with the IMS image",
@@ -1958,12 +1946,8 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "Key/value pair used to further define an Image",
+                                            "description": "User supplied annotations about an image",
                                             "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
                                             "properties": {
                                                 "key": {
                                                     "description": "Template variable to associate with the IMS image",
@@ -2217,12 +2201,8 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "Key/value pair used to further define an Image",
+                                            "description": "User supplied annotations about an image",
                                             "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
                                             "properties": {
                                                 "key": {
                                                     "description": "Template variable to associate with the IMS image",
@@ -9632,12 +9612,8 @@
                                                 "type": "string"
                                             },
                                             "metadata": {
-                                                "description": "Key/value pair used to further define an Image",
+                                                "description": "User supplied annotations about an image",
                                                 "type": "object",
-                                                "required": [
-                                                    "key",
-                                                    "value"
-                                                ],
                                                 "properties": {
                                                     "key": {
                                                         "description": "Template variable to associate with the IMS image",
@@ -9774,12 +9750,8 @@
                                         "type": "string"
                                     },
                                     "metadata": {
-                                        "description": "Key/value pair used to further define an Image",
+                                        "description": "User supplied annotations about an image",
                                         "type": "object",
-                                        "required": [
-                                            "key",
-                                            "value"
-                                        ],
                                         "properties": {
                                             "key": {
                                                 "description": "Template variable to associate with the IMS image",
@@ -10165,12 +10137,8 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "Key/value pair used to further define an Image",
+                                            "description": "User supplied annotations about an image",
                                             "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
                                             "properties": {
                                                 "key": {
                                                     "description": "Template variable to associate with the IMS image",
@@ -10424,12 +10392,8 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "Key/value pair used to further define an Image",
+                                            "description": "User supplied annotations about an image",
                                             "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
                                             "properties": {
                                                 "key": {
                                                     "description": "Template variable to associate with the IMS image",
@@ -14493,12 +14457,8 @@
                                                 "type": "string"
                                             },
                                             "metadata": {
-                                                "description": "Key/value pair used to further define an Image",
+                                                "description": "User supplied annotations about an image",
                                                 "type": "object",
-                                                "required": [
-                                                    "key",
-                                                    "value"
-                                                ],
                                                 "properties": {
                                                     "key": {
                                                         "description": "Template variable to associate with the IMS image",
@@ -14635,12 +14595,8 @@
                                         "type": "string"
                                     },
                                     "metadata": {
-                                        "description": "Key/value pair used to further define an Image",
+                                        "description": "User supplied annotations about an image",
                                         "type": "object",
-                                        "required": [
-                                            "key",
-                                            "value"
-                                        ],
                                         "properties": {
                                             "key": {
                                                 "description": "Template variable to associate with the IMS image",
@@ -15026,12 +14982,8 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "Key/value pair used to further define an Image",
+                                            "description": "User supplied annotations about an image",
                                             "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
                                             "properties": {
                                                 "key": {
                                                     "description": "Template variable to associate with the IMS image",
@@ -15285,12 +15237,8 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "Key/value pair used to further define an Image",
+                                            "description": "User supplied annotations about an image",
                                             "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
                                             "properties": {
                                                 "key": {
                                                     "description": "Template variable to associate with the IMS image",
@@ -19565,12 +19513,8 @@
                         "type": "string"
                     },
                     "metadata": {
-                        "description": "Key/value pair used to further define an Image",
+                        "description": "User supplied annotations about an image",
                         "type": "object",
-                        "required": [
-                            "key",
-                            "value"
-                        ],
                         "properties": {
                             "key": {
                                 "description": "Template variable to associate with the IMS image",

--- a/cray/modules/ims/swagger3.json
+++ b/cray/modules/ims/swagger3.json
@@ -1427,6 +1427,30 @@
                                                     "x86_64"
                                                 ],
                                                 "type": "string"
+                                            },
+                                            "metadata": {
+                                                "description": "An object of key/value associated with an Image",
+                                                "type": "object",
+                                                "properties": {
+                                                    "description": "Key/value pair used to further define an Image",
+                                                    "type": "object",
+                                                    "required": [
+                                                        "key",
+                                                        "value"
+                                                    ],
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Template variable to associate with the IMS image",
+                                                            "example": "includes_additional_packages",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Value variable to associate with the IMS image",
+                                                            "example": "foo,bar,baz",
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
                                             }
                                         }
                                     },
@@ -1549,6 +1573,30 @@
                                             "x86_64"
                                         ],
                                         "type": "string"
+                                    },
+                                    "metadata": {
+                                        "description": "An object of key/value associated with an Image",
+                                        "type": "object",
+                                        "properties": {
+                                            "description": "Key/value pair used to further define an Image",
+                                            "type": "object",
+                                            "required": [
+                                                "key",
+                                                "value"
+                                            ],
+                                            "properties": {
+                                                "key": {
+                                                    "description": "Template variable to associate with the IMS image",
+                                                    "example": "includes_additional_packages",
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "description": "Value variable to associate with the IMS image",
+                                                    "example": "foo,bar,baz",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -1622,6 +1670,30 @@
                                                 "x86_64"
                                             ],
                                             "type": "string"
+                                        },
+                                        "metadata": {
+                                            "description": "An object of key/value associated with an Image",
+                                            "type": "object",
+                                            "properties": {
+                                                "description": "Key/value pair used to further define an Image",
+                                                "type": "object",
+                                                "required": [
+                                                    "key",
+                                                    "value"
+                                                ],
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "Template variable to associate with the IMS image",
+                                                        "example": "includes_additional_packages",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value variable to associate with the IMS image",
+                                                        "example": "foo,bar,baz",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -1896,6 +1968,30 @@
                                                 "x86_64"
                                             ],
                                             "type": "string"
+                                        },
+                                        "metadata": {
+                                            "description": "An object of key/value associated with an Image",
+                                            "type": "object",
+                                            "properties": {
+                                                "description": "Key/value pair used to further define an Image",
+                                                "type": "object",
+                                                "required": [
+                                                    "key",
+                                                    "value"
+                                                ],
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "Template variable to associate with the IMS image",
+                                                        "example": "includes_additional_packages",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value variable to associate with the IMS image",
+                                                        "example": "foo,bar,baz",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -1998,7 +2094,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "description": "Values to update an ImageRecord with",
+                                "description": "Values used to update an existing IMS Image Record",
                                 "type": "object",
                                 "properties": {
                                     "link": {
@@ -2034,6 +2130,34 @@
                                             "x86_64"
                                         ],
                                         "type": "string"
+                                    },
+                                    "metadata": {
+                                        "description": "An object which indicates a number of annotation patch operations relating to image tags.",
+                                        "type": "object",
+                                        "required": [
+                                            "operation",
+                                            "key"
+                                        ],
+                                        "properties": {
+                                            "operation": {
+                                                "description": "How to update a given key within the context of a patch operation",
+                                                "type": "string",
+                                                "enum": [
+                                                    "set",
+                                                    "remove"
+                                                ]
+                                            },
+                                            "key": {
+                                                "description": "The key to update for a given image",
+                                                "type": "string",
+                                                "example": "includes_additional_packages"
+                                            },
+                                            "value": {
+                                                "description": "The value to associate with a key during a patch operation",
+                                                "type": "string",
+                                                "example": "vim,emacs,man"
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -2107,6 +2231,30 @@
                                                 "x86_64"
                                             ],
                                             "type": "string"
+                                        },
+                                        "metadata": {
+                                            "description": "An object of key/value associated with an Image",
+                                            "type": "object",
+                                            "properties": {
+                                                "description": "Key/value pair used to further define an Image",
+                                                "type": "object",
+                                                "required": [
+                                                    "key",
+                                                    "value"
+                                                ],
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "Template variable to associate with the IMS image",
+                                                        "example": "includes_additional_packages",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value variable to associate with the IMS image",
+                                                        "example": "foo,bar,baz",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -6328,6 +6476,30 @@
                                                     "x86_64"
                                                 ],
                                                 "type": "string"
+                                            },
+                                            "metadata": {
+                                                "description": "List of key/value pairs to associate with an Image",
+                                                "type": "object",
+                                                "properties": {
+                                                    "description": "Key/value pair used to further define an Image",
+                                                    "type": "object",
+                                                    "required": [
+                                                        "key",
+                                                        "value"
+                                                    ],
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Template variable to associate with the IMS image",
+                                                            "example": "includes_additional_packages",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Value variable to associate with the IMS image",
+                                                            "example": "foo,bar,baz",
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
                                             }
                                         }
                                     },
@@ -6770,6 +6942,30 @@
                                                 "x86_64"
                                             ],
                                             "type": "string"
+                                        },
+                                        "metadata": {
+                                            "description": "List of key/value pairs to associate with an Image",
+                                            "type": "object",
+                                            "properties": {
+                                                "description": "Key/value pair used to further define an Image",
+                                                "type": "object",
+                                                "required": [
+                                                    "key",
+                                                    "value"
+                                                ],
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "Template variable to associate with the IMS image",
+                                                        "example": "includes_additional_packages",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value variable to associate with the IMS image",
+                                                        "example": "foo,bar,baz",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -9492,6 +9688,30 @@
                                                     "x86_64"
                                                 ],
                                                 "type": "string"
+                                            },
+                                            "metadata": {
+                                                "description": "An object of key/value associated with an Image",
+                                                "type": "object",
+                                                "properties": {
+                                                    "description": "Key/value pair used to further define an Image",
+                                                    "type": "object",
+                                                    "required": [
+                                                        "key",
+                                                        "value"
+                                                    ],
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Template variable to associate with the IMS image",
+                                                            "example": "includes_additional_packages",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Value variable to associate with the IMS image",
+                                                            "example": "foo,bar,baz",
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
                                             }
                                         }
                                     },
@@ -9614,6 +9834,30 @@
                                             "x86_64"
                                         ],
                                         "type": "string"
+                                    },
+                                    "metadata": {
+                                        "description": "An object of key/value associated with an Image",
+                                        "type": "object",
+                                        "properties": {
+                                            "description": "Key/value pair used to further define an Image",
+                                            "type": "object",
+                                            "required": [
+                                                "key",
+                                                "value"
+                                            ],
+                                            "properties": {
+                                                "key": {
+                                                    "description": "Template variable to associate with the IMS image",
+                                                    "example": "includes_additional_packages",
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "description": "Value variable to associate with the IMS image",
+                                                    "example": "foo,bar,baz",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -9694,6 +9938,30 @@
                                                 "x86_64"
                                             ],
                                             "type": "string"
+                                        },
+                                        "metadata": {
+                                            "description": "List of key/value pairs to associate with an Image",
+                                            "type": "object",
+                                            "properties": {
+                                                "description": "Key/value pair used to further define an Image",
+                                                "type": "object",
+                                                "required": [
+                                                    "key",
+                                                    "value"
+                                                ],
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "Template variable to associate with the IMS image",
+                                                        "example": "includes_additional_packages",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value variable to associate with the IMS image",
+                                                        "example": "foo,bar,baz",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -9980,6 +10248,30 @@
                                                 "x86_64"
                                             ],
                                             "type": "string"
+                                        },
+                                        "metadata": {
+                                            "description": "An object of key/value associated with an Image",
+                                            "type": "object",
+                                            "properties": {
+                                                "description": "Key/value pair used to further define an Image",
+                                                "type": "object",
+                                                "required": [
+                                                    "key",
+                                                    "value"
+                                                ],
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "Template variable to associate with the IMS image",
+                                                        "example": "includes_additional_packages",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value variable to associate with the IMS image",
+                                                        "example": "foo,bar,baz",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -10082,7 +10374,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "description": "Values to update an ImageRecord with",
+                                "description": "Values used to update an existing IMS Image Record",
                                 "type": "object",
                                 "properties": {
                                     "link": {
@@ -10118,6 +10410,34 @@
                                             "x86_64"
                                         ],
                                         "type": "string"
+                                    },
+                                    "metadata": {
+                                        "description": "An object which indicates a number of annotation patch operations relating to image tags.",
+                                        "type": "object",
+                                        "required": [
+                                            "operation",
+                                            "key"
+                                        ],
+                                        "properties": {
+                                            "operation": {
+                                                "description": "How to update a given key within the context of a patch operation",
+                                                "type": "string",
+                                                "enum": [
+                                                    "set",
+                                                    "remove"
+                                                ]
+                                            },
+                                            "key": {
+                                                "description": "The key to update for a given image",
+                                                "type": "string",
+                                                "example": "includes_additional_packages"
+                                            },
+                                            "value": {
+                                                "description": "The value to associate with a key during a patch operation",
+                                                "type": "string",
+                                                "example": "vim,emacs,man"
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -10191,6 +10511,30 @@
                                                 "x86_64"
                                             ],
                                             "type": "string"
+                                        },
+                                        "metadata": {
+                                            "description": "An object of key/value associated with an Image",
+                                            "type": "object",
+                                            "properties": {
+                                                "description": "Key/value pair used to further define an Image",
+                                                "type": "object",
+                                                "required": [
+                                                    "key",
+                                                    "value"
+                                                ],
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "Template variable to associate with the IMS image",
+                                                        "example": "includes_additional_packages",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value variable to associate with the IMS image",
+                                                        "example": "foo,bar,baz",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -14240,6 +14584,30 @@
                                                     "x86_64"
                                                 ],
                                                 "type": "string"
+                                            },
+                                            "metadata": {
+                                                "description": "An object of key/value associated with an Image",
+                                                "type": "object",
+                                                "properties": {
+                                                    "description": "Key/value pair used to further define an Image",
+                                                    "type": "object",
+                                                    "required": [
+                                                        "key",
+                                                        "value"
+                                                    ],
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Template variable to associate with the IMS image",
+                                                            "example": "includes_additional_packages",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Value variable to associate with the IMS image",
+                                                            "example": "foo,bar,baz",
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
                                             }
                                         }
                                     },
@@ -14362,6 +14730,30 @@
                                             "x86_64"
                                         ],
                                         "type": "string"
+                                    },
+                                    "metadata": {
+                                        "description": "An object of key/value associated with an Image",
+                                        "type": "object",
+                                        "properties": {
+                                            "description": "Key/value pair used to further define an Image",
+                                            "type": "object",
+                                            "required": [
+                                                "key",
+                                                "value"
+                                            ],
+                                            "properties": {
+                                                "key": {
+                                                    "description": "Template variable to associate with the IMS image",
+                                                    "example": "includes_additional_packages",
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "description": "Value variable to associate with the IMS image",
+                                                    "example": "foo,bar,baz",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -14442,6 +14834,30 @@
                                                 "x86_64"
                                             ],
                                             "type": "string"
+                                        },
+                                        "metadata": {
+                                            "description": "List of key/value pairs to associate with an Image",
+                                            "type": "object",
+                                            "properties": {
+                                                "description": "Key/value pair used to further define an Image",
+                                                "type": "object",
+                                                "required": [
+                                                    "key",
+                                                    "value"
+                                                ],
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "Template variable to associate with the IMS image",
+                                                        "example": "includes_additional_packages",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value variable to associate with the IMS image",
+                                                        "example": "foo,bar,baz",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -14728,6 +15144,30 @@
                                                 "x86_64"
                                             ],
                                             "type": "string"
+                                        },
+                                        "metadata": {
+                                            "description": "An object of key/value associated with an Image",
+                                            "type": "object",
+                                            "properties": {
+                                                "description": "Key/value pair used to further define an Image",
+                                                "type": "object",
+                                                "required": [
+                                                    "key",
+                                                    "value"
+                                                ],
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "Template variable to associate with the IMS image",
+                                                        "example": "includes_additional_packages",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value variable to associate with the IMS image",
+                                                        "example": "foo,bar,baz",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -14830,7 +15270,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "description": "Values to update an ImageRecord with",
+                                "description": "Values used to update an existing IMS Image Record",
                                 "type": "object",
                                 "properties": {
                                     "link": {
@@ -14866,6 +15306,34 @@
                                             "x86_64"
                                         ],
                                         "type": "string"
+                                    },
+                                    "metadata": {
+                                        "description": "An object which indicates a number of annotation patch operations relating to image tags.",
+                                        "type": "object",
+                                        "required": [
+                                            "operation",
+                                            "key"
+                                        ],
+                                        "properties": {
+                                            "operation": {
+                                                "description": "How to update a given key within the context of a patch operation",
+                                                "type": "string",
+                                                "enum": [
+                                                    "set",
+                                                    "remove"
+                                                ]
+                                            },
+                                            "key": {
+                                                "description": "The key to update for a given image",
+                                                "type": "string",
+                                                "example": "includes_additional_packages"
+                                            },
+                                            "value": {
+                                                "description": "The value to associate with a key during a patch operation",
+                                                "type": "string",
+                                                "example": "vim,emacs,man"
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -14939,6 +15407,30 @@
                                                 "x86_64"
                                             ],
                                             "type": "string"
+                                        },
+                                        "metadata": {
+                                            "description": "An object of key/value associated with an Image",
+                                            "type": "object",
+                                            "properties": {
+                                                "description": "Key/value pair used to further define an Image",
+                                                "type": "object",
+                                                "required": [
+                                                    "key",
+                                                    "value"
+                                                ],
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "Template variable to associate with the IMS image",
+                                                        "example": "includes_additional_packages",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value variable to associate with the IMS image",
+                                                        "example": "foo,bar,baz",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -19071,6 +19563,94 @@
                     }
                 }
             },
+            "ImageMetadataAnnotationKeyValuePair": {
+                "description": "Key/value pair used to further define an Image",
+                "type": "object",
+                "required": [
+                    "key",
+                    "value"
+                ],
+                "properties": {
+                    "key": {
+                        "description": "Template variable to associate with the IMS image",
+                        "example": "includes_additional_packages",
+                        "type": "string"
+                    },
+                    "value": {
+                        "description": "Value variable to associate with the IMS image",
+                        "example": "foo,bar,baz",
+                        "type": "string"
+                    }
+                }
+            },
+            "ImagePatchRecord": {
+                "description": "Values used to update an existing IMS Image Record",
+                "type": "object",
+                "properties": {
+                    "link": {
+                        "description": "An Artifact Link Record",
+                        "type": "object",
+                        "required": [
+                            "path",
+                            "type"
+                        ],
+                        "properties": {
+                            "path": {
+                                "description": "Path or location to the artifact in the artifact repository",
+                                "example": "s3://boot-images/1fb58f4e-ad23-489b-89b7-95868fca7ee6/manifest.json",
+                                "type": "string"
+                            },
+                            "etag": {
+                                "description": "Opaque identifier used to uniquely identify the artifact in the artifact repository",
+                                "example": "f04af5f34635ae7c507322985e60c00c-131",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "Identifier specifying the artifact repository where the artifact is located",
+                                "example": "s3",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "arch": {
+                        "description": "Target architecture for the recipe.",
+                        "example": "aarch64",
+                        "enum": [
+                            "aarch64",
+                            "x86_64"
+                        ],
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "description": "An object which indicates a number of annotation patch operations relating to image tags.",
+                        "type": "object",
+                        "required": [
+                            "operation",
+                            "key"
+                        ],
+                        "properties": {
+                            "operation": {
+                                "description": "How to update a given key within the context of a patch operation",
+                                "type": "string",
+                                "enum": [
+                                    "set",
+                                    "remove"
+                                ]
+                            },
+                            "key": {
+                                "description": "The key to update for a given image",
+                                "type": "string",
+                                "example": "includes_additional_packages"
+                            },
+                            "value": {
+                                "description": "The value to associate with a key during a patch operation",
+                                "type": "string",
+                                "example": "vim,emacs,man"
+                            }
+                        }
+                    }
+                }
+            },
             "ImageRecord": {
                 "description": "An Image Record",
                 "type": "object",
@@ -19131,6 +19711,30 @@
                             "x86_64"
                         ],
                         "type": "string"
+                    },
+                    "metadata": {
+                        "description": "An object of key/value associated with an Image",
+                        "type": "object",
+                        "properties": {
+                            "description": "Key/value pair used to further define an Image",
+                            "type": "object",
+                            "required": [
+                                "key",
+                                "value"
+                            ],
+                            "properties": {
+                                "key": {
+                                    "description": "Template variable to associate with the IMS image",
+                                    "example": "includes_additional_packages",
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "description": "Value variable to associate with the IMS image",
+                                    "example": "foo,bar,baz",
+                                    "type": "string"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -19201,46 +19805,30 @@
                             "x86_64"
                         ],
                         "type": "string"
-                    }
-                }
-            },
-            "ImagePatchRecord": {
-                "description": "Values to update an ImageRecord with",
-                "type": "object",
-                "properties": {
-                    "link": {
-                        "description": "An Artifact Link Record",
+                    },
+                    "metadata": {
+                        "description": "List of key/value pairs to associate with an Image",
                         "type": "object",
-                        "required": [
-                            "path",
-                            "type"
-                        ],
                         "properties": {
-                            "path": {
-                                "description": "Path or location to the artifact in the artifact repository",
-                                "example": "s3://boot-images/1fb58f4e-ad23-489b-89b7-95868fca7ee6/manifest.json",
-                                "type": "string"
-                            },
-                            "etag": {
-                                "description": "Opaque identifier used to uniquely identify the artifact in the artifact repository",
-                                "example": "f04af5f34635ae7c507322985e60c00c-131",
-                                "type": "string"
-                            },
-                            "type": {
-                                "description": "Identifier specifying the artifact repository where the artifact is located",
-                                "example": "s3",
-                                "type": "string"
+                            "description": "Key/value pair used to further define an Image",
+                            "type": "object",
+                            "required": [
+                                "key",
+                                "value"
+                            ],
+                            "properties": {
+                                "key": {
+                                    "description": "Template variable to associate with the IMS image",
+                                    "example": "includes_additional_packages",
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "description": "Value variable to associate with the IMS image",
+                                    "example": "foo,bar,baz",
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "arch": {
-                        "description": "Target architecture for the recipe.",
-                        "example": "aarch64",
-                        "enum": [
-                            "aarch64",
-                            "x86_64"
-                        ],
-                        "type": "string"
                     }
                 }
             },

--- a/cray/modules/ims/swagger3.json
+++ b/cray/modules/ims/swagger3.json
@@ -1429,26 +1429,22 @@
                                                 "type": "string"
                                             },
                                             "metadata": {
-                                                "description": "An object of key/value associated with an Image",
+                                                "description": "Key/value pair used to further define an Image",
                                                 "type": "object",
+                                                "required": [
+                                                    "key",
+                                                    "value"
+                                                ],
                                                 "properties": {
-                                                    "description": "Key/value pair used to further define an Image",
-                                                    "type": "object",
-                                                    "required": [
-                                                        "key",
-                                                        "value"
-                                                    ],
-                                                    "properties": {
-                                                        "key": {
-                                                            "description": "Template variable to associate with the IMS image",
-                                                            "example": "includes_additional_packages",
-                                                            "type": "string"
-                                                        },
-                                                        "value": {
-                                                            "description": "Value variable to associate with the IMS image",
-                                                            "example": "foo,bar,baz",
-                                                            "type": "string"
-                                                        }
+                                                    "key": {
+                                                        "description": "Template variable to associate with the IMS image",
+                                                        "example": "includes_additional_packages",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value variable to associate with the IMS image",
+                                                        "example": "foo,bar,baz",
+                                                        "type": "string"
                                                     }
                                                 }
                                             }
@@ -1575,26 +1571,22 @@
                                         "type": "string"
                                     },
                                     "metadata": {
-                                        "description": "An object of key/value associated with an Image",
+                                        "description": "Key/value pair used to further define an Image",
                                         "type": "object",
+                                        "required": [
+                                            "key",
+                                            "value"
+                                        ],
                                         "properties": {
-                                            "description": "Key/value pair used to further define an Image",
-                                            "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
-                                            "properties": {
-                                                "key": {
-                                                    "description": "Template variable to associate with the IMS image",
-                                                    "example": "includes_additional_packages",
-                                                    "type": "string"
-                                                },
-                                                "value": {
-                                                    "description": "Value variable to associate with the IMS image",
-                                                    "example": "foo,bar,baz",
-                                                    "type": "string"
-                                                }
+                                            "key": {
+                                                "description": "Template variable to associate with the IMS image",
+                                                "example": "includes_additional_packages",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Value variable to associate with the IMS image",
+                                                "example": "foo,bar,baz",
+                                                "type": "string"
                                             }
                                         }
                                     }
@@ -1672,26 +1664,22 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "An object of key/value associated with an Image",
+                                            "description": "Key/value pair used to further define an Image",
                                             "type": "object",
+                                            "required": [
+                                                "key",
+                                                "value"
+                                            ],
                                             "properties": {
-                                                "description": "Key/value pair used to further define an Image",
-                                                "type": "object",
-                                                "required": [
-                                                    "key",
-                                                    "value"
-                                                ],
-                                                "properties": {
-                                                    "key": {
-                                                        "description": "Template variable to associate with the IMS image",
-                                                        "example": "includes_additional_packages",
-                                                        "type": "string"
-                                                    },
-                                                    "value": {
-                                                        "description": "Value variable to associate with the IMS image",
-                                                        "example": "foo,bar,baz",
-                                                        "type": "string"
-                                                    }
+                                                "key": {
+                                                    "description": "Template variable to associate with the IMS image",
+                                                    "example": "includes_additional_packages",
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "description": "Value variable to associate with the IMS image",
+                                                    "example": "foo,bar,baz",
+                                                    "type": "string"
                                                 }
                                             }
                                         }
@@ -1970,26 +1958,22 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "An object of key/value associated with an Image",
+                                            "description": "Key/value pair used to further define an Image",
                                             "type": "object",
+                                            "required": [
+                                                "key",
+                                                "value"
+                                            ],
                                             "properties": {
-                                                "description": "Key/value pair used to further define an Image",
-                                                "type": "object",
-                                                "required": [
-                                                    "key",
-                                                    "value"
-                                                ],
-                                                "properties": {
-                                                    "key": {
-                                                        "description": "Template variable to associate with the IMS image",
-                                                        "example": "includes_additional_packages",
-                                                        "type": "string"
-                                                    },
-                                                    "value": {
-                                                        "description": "Value variable to associate with the IMS image",
-                                                        "example": "foo,bar,baz",
-                                                        "type": "string"
-                                                    }
+                                                "key": {
+                                                    "description": "Template variable to associate with the IMS image",
+                                                    "example": "includes_additional_packages",
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "description": "Value variable to associate with the IMS image",
+                                                    "example": "foo,bar,baz",
+                                                    "type": "string"
                                                 }
                                             }
                                         }
@@ -2233,26 +2217,22 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "An object of key/value associated with an Image",
+                                            "description": "Key/value pair used to further define an Image",
                                             "type": "object",
+                                            "required": [
+                                                "key",
+                                                "value"
+                                            ],
                                             "properties": {
-                                                "description": "Key/value pair used to further define an Image",
-                                                "type": "object",
-                                                "required": [
-                                                    "key",
-                                                    "value"
-                                                ],
-                                                "properties": {
-                                                    "key": {
-                                                        "description": "Template variable to associate with the IMS image",
-                                                        "example": "includes_additional_packages",
-                                                        "type": "string"
-                                                    },
-                                                    "value": {
-                                                        "description": "Value variable to associate with the IMS image",
-                                                        "example": "foo,bar,baz",
-                                                        "type": "string"
-                                                    }
+                                                "key": {
+                                                    "description": "Template variable to associate with the IMS image",
+                                                    "example": "includes_additional_packages",
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "description": "Value variable to associate with the IMS image",
+                                                    "example": "foo,bar,baz",
+                                                    "type": "string"
                                                 }
                                             }
                                         }
@@ -6480,26 +6460,7 @@
                                             "metadata": {
                                                 "description": "List of key/value pairs to associate with an Image",
                                                 "type": "object",
-                                                "properties": {
-                                                    "description": "Key/value pair used to further define an Image",
-                                                    "type": "object",
-                                                    "required": [
-                                                        "key",
-                                                        "value"
-                                                    ],
-                                                    "properties": {
-                                                        "key": {
-                                                            "description": "Template variable to associate with the IMS image",
-                                                            "example": "includes_additional_packages",
-                                                            "type": "string"
-                                                        },
-                                                        "value": {
-                                                            "description": "Value variable to associate with the IMS image",
-                                                            "example": "foo,bar,baz",
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                }
+                                                "properties": false
                                             }
                                         }
                                     },
@@ -6946,26 +6907,7 @@
                                         "metadata": {
                                             "description": "List of key/value pairs to associate with an Image",
                                             "type": "object",
-                                            "properties": {
-                                                "description": "Key/value pair used to further define an Image",
-                                                "type": "object",
-                                                "required": [
-                                                    "key",
-                                                    "value"
-                                                ],
-                                                "properties": {
-                                                    "key": {
-                                                        "description": "Template variable to associate with the IMS image",
-                                                        "example": "includes_additional_packages",
-                                                        "type": "string"
-                                                    },
-                                                    "value": {
-                                                        "description": "Value variable to associate with the IMS image",
-                                                        "example": "foo,bar,baz",
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            }
+                                            "properties": false
                                         }
                                     }
                                 }
@@ -9690,26 +9632,22 @@
                                                 "type": "string"
                                             },
                                             "metadata": {
-                                                "description": "An object of key/value associated with an Image",
+                                                "description": "Key/value pair used to further define an Image",
                                                 "type": "object",
+                                                "required": [
+                                                    "key",
+                                                    "value"
+                                                ],
                                                 "properties": {
-                                                    "description": "Key/value pair used to further define an Image",
-                                                    "type": "object",
-                                                    "required": [
-                                                        "key",
-                                                        "value"
-                                                    ],
-                                                    "properties": {
-                                                        "key": {
-                                                            "description": "Template variable to associate with the IMS image",
-                                                            "example": "includes_additional_packages",
-                                                            "type": "string"
-                                                        },
-                                                        "value": {
-                                                            "description": "Value variable to associate with the IMS image",
-                                                            "example": "foo,bar,baz",
-                                                            "type": "string"
-                                                        }
+                                                    "key": {
+                                                        "description": "Template variable to associate with the IMS image",
+                                                        "example": "includes_additional_packages",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value variable to associate with the IMS image",
+                                                        "example": "foo,bar,baz",
+                                                        "type": "string"
                                                     }
                                                 }
                                             }
@@ -9836,26 +9774,22 @@
                                         "type": "string"
                                     },
                                     "metadata": {
-                                        "description": "An object of key/value associated with an Image",
+                                        "description": "Key/value pair used to further define an Image",
                                         "type": "object",
+                                        "required": [
+                                            "key",
+                                            "value"
+                                        ],
                                         "properties": {
-                                            "description": "Key/value pair used to further define an Image",
-                                            "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
-                                            "properties": {
-                                                "key": {
-                                                    "description": "Template variable to associate with the IMS image",
-                                                    "example": "includes_additional_packages",
-                                                    "type": "string"
-                                                },
-                                                "value": {
-                                                    "description": "Value variable to associate with the IMS image",
-                                                    "example": "foo,bar,baz",
-                                                    "type": "string"
-                                                }
+                                            "key": {
+                                                "description": "Template variable to associate with the IMS image",
+                                                "example": "includes_additional_packages",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Value variable to associate with the IMS image",
+                                                "example": "foo,bar,baz",
+                                                "type": "string"
                                             }
                                         }
                                     }
@@ -9942,26 +9876,7 @@
                                         "metadata": {
                                             "description": "List of key/value pairs to associate with an Image",
                                             "type": "object",
-                                            "properties": {
-                                                "description": "Key/value pair used to further define an Image",
-                                                "type": "object",
-                                                "required": [
-                                                    "key",
-                                                    "value"
-                                                ],
-                                                "properties": {
-                                                    "key": {
-                                                        "description": "Template variable to associate with the IMS image",
-                                                        "example": "includes_additional_packages",
-                                                        "type": "string"
-                                                    },
-                                                    "value": {
-                                                        "description": "Value variable to associate with the IMS image",
-                                                        "example": "foo,bar,baz",
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            }
+                                            "properties": false
                                         }
                                     }
                                 }
@@ -10250,26 +10165,22 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "An object of key/value associated with an Image",
+                                            "description": "Key/value pair used to further define an Image",
                                             "type": "object",
+                                            "required": [
+                                                "key",
+                                                "value"
+                                            ],
                                             "properties": {
-                                                "description": "Key/value pair used to further define an Image",
-                                                "type": "object",
-                                                "required": [
-                                                    "key",
-                                                    "value"
-                                                ],
-                                                "properties": {
-                                                    "key": {
-                                                        "description": "Template variable to associate with the IMS image",
-                                                        "example": "includes_additional_packages",
-                                                        "type": "string"
-                                                    },
-                                                    "value": {
-                                                        "description": "Value variable to associate with the IMS image",
-                                                        "example": "foo,bar,baz",
-                                                        "type": "string"
-                                                    }
+                                                "key": {
+                                                    "description": "Template variable to associate with the IMS image",
+                                                    "example": "includes_additional_packages",
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "description": "Value variable to associate with the IMS image",
+                                                    "example": "foo,bar,baz",
+                                                    "type": "string"
                                                 }
                                             }
                                         }
@@ -10513,26 +10424,22 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "An object of key/value associated with an Image",
+                                            "description": "Key/value pair used to further define an Image",
                                             "type": "object",
+                                            "required": [
+                                                "key",
+                                                "value"
+                                            ],
                                             "properties": {
-                                                "description": "Key/value pair used to further define an Image",
-                                                "type": "object",
-                                                "required": [
-                                                    "key",
-                                                    "value"
-                                                ],
-                                                "properties": {
-                                                    "key": {
-                                                        "description": "Template variable to associate with the IMS image",
-                                                        "example": "includes_additional_packages",
-                                                        "type": "string"
-                                                    },
-                                                    "value": {
-                                                        "description": "Value variable to associate with the IMS image",
-                                                        "example": "foo,bar,baz",
-                                                        "type": "string"
-                                                    }
+                                                "key": {
+                                                    "description": "Template variable to associate with the IMS image",
+                                                    "example": "includes_additional_packages",
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "description": "Value variable to associate with the IMS image",
+                                                    "example": "foo,bar,baz",
+                                                    "type": "string"
                                                 }
                                             }
                                         }
@@ -14586,26 +14493,22 @@
                                                 "type": "string"
                                             },
                                             "metadata": {
-                                                "description": "An object of key/value associated with an Image",
+                                                "description": "Key/value pair used to further define an Image",
                                                 "type": "object",
+                                                "required": [
+                                                    "key",
+                                                    "value"
+                                                ],
                                                 "properties": {
-                                                    "description": "Key/value pair used to further define an Image",
-                                                    "type": "object",
-                                                    "required": [
-                                                        "key",
-                                                        "value"
-                                                    ],
-                                                    "properties": {
-                                                        "key": {
-                                                            "description": "Template variable to associate with the IMS image",
-                                                            "example": "includes_additional_packages",
-                                                            "type": "string"
-                                                        },
-                                                        "value": {
-                                                            "description": "Value variable to associate with the IMS image",
-                                                            "example": "foo,bar,baz",
-                                                            "type": "string"
-                                                        }
+                                                    "key": {
+                                                        "description": "Template variable to associate with the IMS image",
+                                                        "example": "includes_additional_packages",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value variable to associate with the IMS image",
+                                                        "example": "foo,bar,baz",
+                                                        "type": "string"
                                                     }
                                                 }
                                             }
@@ -14732,26 +14635,22 @@
                                         "type": "string"
                                     },
                                     "metadata": {
-                                        "description": "An object of key/value associated with an Image",
+                                        "description": "Key/value pair used to further define an Image",
                                         "type": "object",
+                                        "required": [
+                                            "key",
+                                            "value"
+                                        ],
                                         "properties": {
-                                            "description": "Key/value pair used to further define an Image",
-                                            "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
-                                            "properties": {
-                                                "key": {
-                                                    "description": "Template variable to associate with the IMS image",
-                                                    "example": "includes_additional_packages",
-                                                    "type": "string"
-                                                },
-                                                "value": {
-                                                    "description": "Value variable to associate with the IMS image",
-                                                    "example": "foo,bar,baz",
-                                                    "type": "string"
-                                                }
+                                            "key": {
+                                                "description": "Template variable to associate with the IMS image",
+                                                "example": "includes_additional_packages",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Value variable to associate with the IMS image",
+                                                "example": "foo,bar,baz",
+                                                "type": "string"
                                             }
                                         }
                                     }
@@ -14838,26 +14737,7 @@
                                         "metadata": {
                                             "description": "List of key/value pairs to associate with an Image",
                                             "type": "object",
-                                            "properties": {
-                                                "description": "Key/value pair used to further define an Image",
-                                                "type": "object",
-                                                "required": [
-                                                    "key",
-                                                    "value"
-                                                ],
-                                                "properties": {
-                                                    "key": {
-                                                        "description": "Template variable to associate with the IMS image",
-                                                        "example": "includes_additional_packages",
-                                                        "type": "string"
-                                                    },
-                                                    "value": {
-                                                        "description": "Value variable to associate with the IMS image",
-                                                        "example": "foo,bar,baz",
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            }
+                                            "properties": false
                                         }
                                     }
                                 }
@@ -15146,26 +15026,22 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "An object of key/value associated with an Image",
+                                            "description": "Key/value pair used to further define an Image",
                                             "type": "object",
+                                            "required": [
+                                                "key",
+                                                "value"
+                                            ],
                                             "properties": {
-                                                "description": "Key/value pair used to further define an Image",
-                                                "type": "object",
-                                                "required": [
-                                                    "key",
-                                                    "value"
-                                                ],
-                                                "properties": {
-                                                    "key": {
-                                                        "description": "Template variable to associate with the IMS image",
-                                                        "example": "includes_additional_packages",
-                                                        "type": "string"
-                                                    },
-                                                    "value": {
-                                                        "description": "Value variable to associate with the IMS image",
-                                                        "example": "foo,bar,baz",
-                                                        "type": "string"
-                                                    }
+                                                "key": {
+                                                    "description": "Template variable to associate with the IMS image",
+                                                    "example": "includes_additional_packages",
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "description": "Value variable to associate with the IMS image",
+                                                    "example": "foo,bar,baz",
+                                                    "type": "string"
                                                 }
                                             }
                                         }
@@ -15409,26 +15285,22 @@
                                             "type": "string"
                                         },
                                         "metadata": {
-                                            "description": "An object of key/value associated with an Image",
+                                            "description": "Key/value pair used to further define an Image",
                                             "type": "object",
+                                            "required": [
+                                                "key",
+                                                "value"
+                                            ],
                                             "properties": {
-                                                "description": "Key/value pair used to further define an Image",
-                                                "type": "object",
-                                                "required": [
-                                                    "key",
-                                                    "value"
-                                                ],
-                                                "properties": {
-                                                    "key": {
-                                                        "description": "Template variable to associate with the IMS image",
-                                                        "example": "includes_additional_packages",
-                                                        "type": "string"
-                                                    },
-                                                    "value": {
-                                                        "description": "Value variable to associate with the IMS image",
-                                                        "example": "foo,bar,baz",
-                                                        "type": "string"
-                                                    }
+                                                "key": {
+                                                    "description": "Template variable to associate with the IMS image",
+                                                    "example": "includes_additional_packages",
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "description": "Value variable to associate with the IMS image",
+                                                    "example": "foo,bar,baz",
+                                                    "type": "string"
                                                 }
                                             }
                                         }
@@ -19563,26 +19435,6 @@
                     }
                 }
             },
-            "ImageMetadataAnnotationKeyValuePair": {
-                "description": "Key/value pair used to further define an Image",
-                "type": "object",
-                "required": [
-                    "key",
-                    "value"
-                ],
-                "properties": {
-                    "key": {
-                        "description": "Template variable to associate with the IMS image",
-                        "example": "includes_additional_packages",
-                        "type": "string"
-                    },
-                    "value": {
-                        "description": "Value variable to associate with the IMS image",
-                        "example": "foo,bar,baz",
-                        "type": "string"
-                    }
-                }
-            },
             "ImagePatchRecord": {
                 "description": "Values used to update an existing IMS Image Record",
                 "type": "object",
@@ -19713,26 +19565,22 @@
                         "type": "string"
                     },
                     "metadata": {
-                        "description": "An object of key/value associated with an Image",
+                        "description": "Key/value pair used to further define an Image",
                         "type": "object",
+                        "required": [
+                            "key",
+                            "value"
+                        ],
                         "properties": {
-                            "description": "Key/value pair used to further define an Image",
-                            "type": "object",
-                            "required": [
-                                "key",
-                                "value"
-                            ],
-                            "properties": {
-                                "key": {
-                                    "description": "Template variable to associate with the IMS image",
-                                    "example": "includes_additional_packages",
-                                    "type": "string"
-                                },
-                                "value": {
-                                    "description": "Value variable to associate with the IMS image",
-                                    "example": "foo,bar,baz",
-                                    "type": "string"
-                                }
+                            "key": {
+                                "description": "Template variable to associate with the IMS image",
+                                "example": "includes_additional_packages",
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Value variable to associate with the IMS image",
+                                "example": "foo,bar,baz",
+                                "type": "string"
                             }
                         }
                     }
@@ -19809,26 +19657,7 @@
                     "metadata": {
                         "description": "List of key/value pairs to associate with an Image",
                         "type": "object",
-                        "properties": {
-                            "description": "Key/value pair used to further define an Image",
-                            "type": "object",
-                            "required": [
-                                "key",
-                                "value"
-                            ],
-                            "properties": {
-                                "key": {
-                                    "description": "Template variable to associate with the IMS image",
-                                    "example": "includes_additional_packages",
-                                    "type": "string"
-                                },
-                                "value": {
-                                    "description": "Value variable to associate with the IMS image",
-                                    "example": "foo,bar,baz",
-                                    "type": "string"
-                                }
-                            }
-                        }
+                        "properties": false
                     }
                 }
             },


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Requires: https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8833

#### Issue Type

- RFE Pull Request

Expands the definition of images to include user provided key value pairs of information as associated with an image.

### Prerequisites
- [x] I tested this on internal system.

Tested on `wasp`.
