### PR TITLE
CASMTRIAGE-7147: Add BOS v2 max_component_batch_size option

### DIFF
--- a/cray/modules/bos/openapi.yaml
+++ b/cray/modules/bos/openapi.yaml
@@ -1211,6 +1211,12 @@ components:
           type: integer
           description: The default maximum number attempts per node for failed actions.
           example: 1
+        max_component_batch_size:
+          type: integer
+          description: The maximum number of components that a BOS operator will process at once. 0 means no limit.
+          example: 1000
+          minimum: 0
+          maximum: 131071
       additionalProperties: true
   requestBodies:
     V2sessionCreateRequest:

--- a/cray/modules/bos/swagger3.json
+++ b/cray/modules/bos/swagger3.json
@@ -2626,6 +2626,13 @@
             "type": "integer",
             "description": "The default maximum number attempts per node for failed actions.",
             "example": 1
+          },
+          "max_component_batch_size": {
+            "type": "integer",
+            "description": "The maximum number of components that a BOS operator will process at once. 0 means no limit.",
+            "example": 1000,
+            "minimum": 0,
+            "maximum": 131071
           }
         },
         "additionalProperties": true
@@ -3633,6 +3640,13 @@
                   "type": "integer",
                   "description": "The default maximum number attempts per node for failed actions.",
                   "example": 1
+                },
+                "max_component_batch_size": {
+                    "type": "integer",
+                    "description": "The maximum number of components that a BOS operator will process at once. 0 means no limit.",
+                    "example": 1000,
+                    "minimum": 0,
+                    "maximum": 131071
                 }
               },
               "additionalProperties": true
@@ -5161,6 +5175,13 @@
                   "type": "integer",
                   "description": "The default maximum number attempts per node for failed actions.",
                   "example": 1
+                },
+                "max_component_batch_size": {
+                    "type": "integer",
+                    "description": "The maximum number of components that a BOS operator will process at once. 0 means no limit.",
+                    "example": 1000,
+                    "minimum": 0,
+                    "maximum": 131071
                 }
               },
               "additionalProperties": true
@@ -14630,6 +14651,13 @@
                       "type": "integer",
                       "description": "The default maximum number attempts per node for failed actions.",
                       "example": 1
+                    },
+                    "max_component_batch_size": {
+                        "type": "integer",
+                        "description": "The maximum number of components that a BOS operator will process at once. 0 means no limit.",
+                        "example": 1000,
+                        "minimum": 0,
+                        "maximum": 131071
                     }
                   },
                   "additionalProperties": true
@@ -14701,6 +14729,13 @@
                     "type": "integer",
                     "description": "The default maximum number attempts per node for failed actions.",
                     "example": 1
+                  },
+                  "max_component_batch_size": {
+                    "type": "integer",
+                    "description": "The maximum number of components that a BOS operator will process at once. 0 means no limit.",
+                    "example": 1000,
+                    "minimum": 0,
+                    "maximum": 131071
                   }
                 },
                 "additionalProperties": true
@@ -14761,6 +14796,13 @@
                       "type": "integer",
                       "description": "The default maximum number attempts per node for failed actions.",
                       "example": 1
+                    },
+                    "max_component_batch_size": {
+                      "type": "integer",
+                      "description": "The maximum number of components that a BOS operator will process at once. 0 means no limit.",
+                      "example": 1000,
+                      "minimum": 0,
+                      "maximum": 131071
                     }
                   },
                   "additionalProperties": true


### PR DESCRIPTION
CSM 1.5 PR for https://github.com/Cray-HPE/craycli/pull/155

See primary [BOS source PR](https://github.com/Cray-HPE/bos/pull/339) for more details.

All PRs:

BOS:
CSM 1.4: https://github.com/Cray-HPE/bos/pull/339
CSM 1.5: https://github.com/Cray-HPE/bos/pull/340
CSM 1.6: https://github.com/Cray-HPE/bos/pull/341

CLI:
CSM 1.4: https://github.com/Cray-HPE/craycli/pull/155
CSM 1.5: https://github.com/Cray-HPE/craycli/pull/156
CSM 1.6: https://github.com/Cray-HPE/craycli/pull/157