### PR TITLE
CASMCMS-9162: Add the cfs_read_timeout option.

### DIFF
--- a/cray/modules/bos/openapi.yaml
+++ b/cray/modules/bos/openapi.yaml
@@ -1182,6 +1182,13 @@ components:
         Options for the boot orchestration service.
       type: object
       properties:
+        cfs_read_timeout:
+          type: integer
+          description: |
+            The amount of time (in seconds) to wait for a response before timing out a request to CFS
+          example: 20
+          minimum: 10
+          maximum: 86400
         cleanup_completed_session_ttl:
           type: string
           description: Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior.

--- a/cray/modules/bos/swagger3.json
+++ b/cray/modules/bos/swagger3.json
@@ -2582,6 +2582,13 @@
         "description": "Options for the boot orchestration service.\n",
         "type": "object",
         "properties": {
+          "cfs_read_timeout": {
+            "type": "integer",
+            "description": "The amount of time (in seconds) to wait for a response before timing out a request to CFS.\n",
+            "example": 20,
+            "minimum": 10,
+            "maximum": 86400
+          },
           "cleanup_completed_session_ttl": {
             "type": "string",
             "description": "Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior."
@@ -3600,6 +3607,13 @@
               "description": "Options for the boot orchestration service.\n",
               "type": "object",
               "properties": {
+                "cfs_read_timeout": {
+                  "type": "integer",
+                  "description": "The amount of time (in seconds) to wait for a response before timing out a request to CFS.\n",
+                  "example": 20,
+                  "minimum": 10,
+                  "maximum": 86400
+                },
                 "cleanup_completed_session_ttl": {
                   "type": "string",
                   "description": "Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior."
@@ -5139,6 +5153,13 @@
               "description": "Options for the boot orchestration service.\n",
               "type": "object",
               "properties": {
+                "cfs_read_timeout": {
+                  "type": "integer",
+                  "description": "The amount of time (in seconds) to wait for a response before timing out a request to CFS.\n",
+                  "example": 20,
+                  "minimum": 10,
+                  "maximum": 86400
+                },
                 "cleanup_completed_session_ttl": {
                   "type": "string",
                   "description": "Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior."
@@ -14619,6 +14640,13 @@
                   "description": "Options for the boot orchestration service.\n",
                   "type": "object",
                   "properties": {
+                    "cfs_read_timeout": {
+                      "type": "integer",
+                      "description": "The amount of time (in seconds) to wait for a response before timing out a request to CFS.\n",
+                      "example": 20,
+                      "minimum": 10,
+                      "maximum": 86400
+                    },
                     "cleanup_completed_session_ttl": {
                       "type": "string",
                       "description": "Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior."
@@ -14701,6 +14729,13 @@
                 "description": "Options for the boot orchestration service.\n",
                 "type": "object",
                 "properties": {
+                  "cfs_read_timeout": {
+                    "type": "integer",
+                    "description": "The amount of time (in seconds) to wait for a response before timing out a request to CFS.\n",
+                    "example": 20,
+                    "minimum": 10,
+                    "maximum": 86400
+                  },
                   "cleanup_completed_session_ttl": {
                     "type": "string",
                     "description": "Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior."
@@ -14772,6 +14807,13 @@
                   "description": "Options for the boot orchestration service.\n",
                   "type": "object",
                   "properties": {
+                    "cfs_read_timeout": {
+                      "type": "integer",
+                      "description": "The amount of time (in seconds) to wait for a response before timing out a request to CFS.\n",
+                      "example": 20,
+                      "minimum": 10,
+                      "maximum": 86400
+                    },
                     "cleanup_completed_session_ttl": {
                       "type": "string",
                       "description": "Delete complete sessions that are older than cleanup_completed_session_ttl (in hours). 0h disables cleanup behavior."


### PR DESCRIPTION
(cherry picked from commit 7541dac36dabd971b1b7367e3a36b94ee1abffcc)

### Summary and Scope
Add the cfs_read_timeout option.
<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMCMS-9162
- Requires:
- Relates to:

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
I tested this on Drax, and I was able to update the cfs-read-timeout option.

### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
