### PR TITLE
Latest only on default branch

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -6,7 +6,6 @@ on:
       - 'v?[0-9]+.[0-9]+.[0-9]+.post[0-9]+'
   workflow_dispatch:
 
-
 env:
   STREAM: stable
 jobs:

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   STREAM: stable
+  LATEST: false
 jobs:
   Promote:
     runs-on: ubuntu-latest
@@ -25,10 +26,23 @@ jobs:
         with:
           STREAM: ${{ env.STREAM }}
 
+      - name: Get Branch
+        run: |
+          mapfile -t branches < <(git branch -r --contains ${{ github.ref }} | awk '{print $1}')
+          echo "${branches[@]}"
+          for branch in "${branches[@]}"; do
+            branch_name="${branch/origin\/}"
+            echo "${branch_name}"
+            if [ "${branch_name}" = 'master' ]; then
+              echo LATEST=true >> $GITHUB_ENV
+              break
+            fi
+          done
+
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true # if the job is re-ran to catch missed artifacts, allow updates
           generateReleaseNotes: true
           artifacts: ${{ env.DIR_UPLOAD }}/*
           prerelease: false
-          makeLatest: true
+          makeLatest: ${{ fromJSON(env.LATEST) }}


### PR DESCRIPTION
Do not mark stable tags from release or maintenance branches as latest.

Prevents maintenance/release branches from declaring themselves as "latest" over a tag taken from the default branch.