### PR TITLE
CASMCMS-8131: BOS: Remove disable_components_on_completion option, update API spec

### DIFF
--- a/cray/modules/bos/openapi.yaml
+++ b/cray/modules/bos/openapi.yaml
@@ -3,7 +3,7 @@ openapi: "3.0.3"
 
 info:
   title: "Boot Orchestration Service"
-  version: "2.30.0"
+  version: "2.48.0"
   description: |
     The Boot Orchestration Service (BOS) provides coordinated provisioning actions
     over defined hardware sets to enable boot, reboot, shutdown, configuration and
@@ -263,39 +263,6 @@ components:
         example: "Compute"
         minLength: 1
         maxLength: 127
-    ProblemDetails:
-      description: An error response for RFC 7807 problem details.
-      type: object
-      properties:
-        type:
-          description: |
-            Relative URI reference to the type of problem which includes human
-            readable documentation.
-          type: string
-          format: uri
-          default: "about:blank"
-        title:
-          description: |
-            Short, human-readable summary of the problem, should not change by
-            occurrence.
-          type: string
-        status:
-          description: HTTP status code
-          type: integer
-          example: 400
-        instance:
-          description: |
-            A relative URI reference that identifies the specific occurrence of
-            the problem
-          format: uri
-          type: string
-        detail:
-          description: |
-            A human-readable explanation specific to this occurrence of the
-            problem. Focus on helping correct the problem, rather than giving
-            debugging information.
-          type: string
-      additionalProperties: false
     SessionLimit:
       type: string
       description: |
@@ -420,6 +387,29 @@ components:
           $ref: '#/components/schemas/LinkListReadOnly'
       additionalProperties: false
       required: [ boot_sets ]
+    V2SessionTemplatePatch:
+      type: object
+      description: Data to update an existing Session Template record.
+      properties:
+        description:
+          $ref: '#/components/schemas/SessionTemplateDescription'
+        enable_cfs:
+          $ref: '#/components/schemas/EnableCfs'
+        cfs:
+          $ref: '#/components/schemas/V2CfsParameters'
+        boot_sets:
+          type: object
+          description: |
+            Mapping from Boot Set names to Boot Sets.
+
+            * Boot Set names must be 1-127 characters in length.
+            * Boot Set names must use only letters, digits, periods (.), dashes (-), and underscores (_).
+            * Boot Set names must begin and end with a letter or digit.
+          minProperties: 1
+          maxProperties: 127
+          additionalProperties:
+            $ref: '#/components/schemas/V2BootSet'
+      additionalProperties: false
     V2SessionTemplateValidation:
       description: |
         Message describing errors or incompleteness in a Session Template.
@@ -661,6 +651,19 @@ components:
           description: |
             The current duration of the ongoing Session or final duration of the completed Session.
       additionalProperties: false
+    V2SessionExtendedStatusErrorComponents:
+      type: object
+      description: Summary of Components impacted by an error.
+      properties:
+        count:
+          type: integer
+          description: The number of Components impacted by the error.
+        list:
+          type: string
+          description: |
+            A comma-separated list of the impacted Components.
+            If more than 10 Components are impacted, the first 10 are shown, following by a trailing '...'
+      additionalProperties: false
     V2SessionExtendedStatus:
       type: object
       description: |
@@ -689,7 +692,9 @@ components:
         error_summary:
           type: object
           description: |
-            A summary of the errors currently listed by all Components
+            A mapping from error messages to a summary of the impacted Components.
+          additionalProperties:
+            $ref: '#/components/schemas/V2SessionExtendedStatusErrorComponents'
         timing:
           $ref: '#/components/schemas/V2SessionExtendedStatusTiming'
       additionalProperties: false
@@ -777,9 +782,7 @@ components:
         last_updated:
           $ref: '#/components/schemas/V2ComponentLastUpdated'
         action:
-          type: string
-          description: A description of the most recent operator/action to impact the Component.
-          maxLength: 1024
+          $ref: '#/components/schemas/V2ComponentAction'
         failed:
           type: boolean
           description: Denotes if the last action failed to accomplish its task
@@ -805,10 +808,14 @@ components:
           minimum: 0
           maximum: 1048576
       additionalProperties: false
+    V2ComponentAction:
+        type: string
+        description: A description of the most recent operator/action to impact the Component.
+        enum: ['actual_state_cleanup', 'apply_staged', 'newly_discovered', 'powering_off_forcefully', 'powering_off_gracefully', 'powering_on', 'session_setup']
     V2ComponentPhase:
       type: string
       description: The current phase of the Component in the boot process.
-      maxLength: 128
+      enum: ['configuring', 'powering_off', 'powering_on', '']
     V2ComponentStatus:
       description: Status information for the Component
       type: object
@@ -1016,11 +1023,6 @@ components:
           example: 1
           minimum: 0
           maximum: 1048576
-        disable_components_on_completion:
-          type: boolean
-          description: |
-            If true, when a Session has brought a Component to its desired state, that Component will be marked as disabled in BOS.
-            If false, BOS will continue to maintain the state of the nodes declaratively, even after a Session finishes.
         discovery_frequency:
           type: integer
           description: How frequently the BOS discovery agent syncs new Components from HSM (in seconds)
@@ -1113,6 +1115,104 @@ components:
       additionalProperties: true
       minProperties: 1
       maxProperties: 1024
+
+    # Error response schemas
+    ProblemDetails:
+      description: An error response for RFC 7807 problem details.
+      type: object
+      properties:
+        type:
+          description: |
+            Relative URI reference to the type of problem which includes human
+            readable documentation.
+          type: string
+          format: uri
+          default: "about:blank"
+        title:
+          description: |
+            Short, human-readable summary of the problem, should not change by
+            occurrence.
+          type: string
+        status:
+          description: HTTP status code
+          type: integer
+          example: 400
+        instance:
+          description: |
+            A relative URI reference that identifies the specific occurrence of
+            the problem
+          format: uri
+          type: string
+        detail:
+          description: |
+            A human-readable explanation specific to this occurrence of the
+            problem. Focus on helping correct the problem, rather than giving
+            debugging information.
+          type: string
+      additionalProperties: false
+    # OAS 3.0 does not support constant values
+    # The closest we can do is single-value enum + default
+    ProblemAlreadyExists:
+      type: object
+      properties:
+        title:
+          type: string
+          enum: [ "The resource to be created already exists" ]
+          default: "The resource to be created already exists"
+        status:
+          type: integer
+          enum: [ 409 ]
+          default: 409
+      additionalProperties: true
+    ProblemBadRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          enum: [ "Bad Request" ]
+          default: "Bad Request"
+        status:
+          type: integer
+          enum: [ 400 ]
+          default: 400
+      additionalProperties: true
+    ProblemResourceNotFound:
+      type: object
+      properties:
+        title:
+          type: string
+          enum: [ "The resource was not found" ]
+          default: "The resource was not found"
+        status:
+          type: integer
+          enum: [ 404 ]
+          default: 404
+      additionalProperties: true
+    ProblemUpdateConflict:
+      type: object
+      properties:
+        title:
+          type: string
+          enum: [ "The update was not allowed due to a conflict" ]
+          default: "The update was not allowed due to a conflict"
+      additionalProperties: true
+    ProblemServiceUnavailable:
+      type: object
+      properties:
+        title:
+          type: string
+          enum: [ "Service Unavailable" ]
+          default: "Service Unavailable"
+      additionalProperties: true
+    ProblemInternalError:
+      type: object
+      properties:
+        title:
+          type: string
+          enum: [ "An Internal Server Error occurred handling the request" ]
+          default: "An Internal Server Error occurred handling the request"
+      additionalProperties: true
+
 
   requestBodies:
     V2sessionCreateRequest:
@@ -1246,57 +1346,56 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/V2Options'
+
     # Errors
     AlreadyExists:
       description: The resource to be created already exists
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/ProblemDetails'
+            allOf:
+              - $ref: '#/components/schemas/ProblemDetails'
+              - $ref: '#/components/schemas/ProblemAlreadyExists'
     BadRequest:
       description: Bad Request
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/ProblemDetails'
-    BadRequestOrMultiTenancyNotSupported:
-      description: |
-        Multi-tenancy is not supported for this request.
-        If no tenant was specified, then the request was bad for another reason.
-      content:
-        application/problem+json:
-          schema:
-            $ref: '#/components/schemas/ProblemDetails'
-    MultiTenancyNotSupported:
-      description: Multi-tenancy is not supported for this BOS request.
-      content:
-        application/problem+json:
-          schema:
-            $ref: '#/components/schemas/ProblemDetails'
+            allOf:
+              - $ref: '#/components/schemas/ProblemDetails'
+              - $ref: '#/components/schemas/ProblemBadRequest'
     ResourceNotFound:
       description: The resource was not found.
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/ProblemDetails'
+            allOf:
+              - $ref: '#/components/schemas/ProblemDetails'
+              - $ref: '#/components/schemas/ProblemResourceNotFound'
     UpdateConflict:
       description: The update was not allowed due to a conflict.
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/ProblemDetails'
+            allOf:
+              - $ref: '#/components/schemas/ProblemDetails'
+              - $ref: '#/components/schemas/ProblemUpdateConflict'
     ServiceUnavailable:
       description: Service Unavailable
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/ProblemDetails'
+            allOf:
+              - $ref: '#/components/schemas/ProblemDetails'
+              - $ref: '#/components/schemas/ProblemServiceUnavailable'
     InternalError:
       description: An Internal Server Error occurred handling the request.
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/ProblemDetails'
+            allOf:
+              - $ref: '#/components/schemas/ProblemDetails'
+              - $ref: '#/components/schemas/ProblemInternalError'
 
   parameters:
     TemplateIdPathParam:
@@ -1493,7 +1592,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/V2SessionTemplate'
+              $ref: '#/components/schemas/V2SessionTemplatePatch'
       responses:
         200:
           $ref: '#/components/responses/V2SessionTemplateDetails'
@@ -1550,6 +1649,8 @@ paths:
           $ref: '#/components/responses/V2SessionDetails'
         400:
           $ref: '#/components/responses/BadRequest'
+        409:
+          $ref: '#/components/responses/AlreadyExists'
     get:
       summary: List Sessions
       parameters:
@@ -1711,6 +1812,21 @@ paths:
           in: query
           description: |-
             Retrieve the Components with the given status.
+        - name: start_after_id
+          schema:
+            $ref: '#/components/schemas/V2ComponentId'
+          in: query
+          description: |-
+            Begin listing Components after the specified ID. Used for paging.
+        - name: page_size
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 1048576
+          in: query
+          description: |-
+            Maximum number of Components to include in response. Used for paging. 0 means no limit
+            (which is the same as not specifying this parameter).
       description: |-
         Retrieve the full collection of Components in the form of a
         ComponentArray. Full results can also be filtered by query
@@ -1746,6 +1862,19 @@ paths:
           $ref: '#/components/responses/BadRequest'
     post:
       summary: Update a collection of Components
+      parameters:
+        - name: skip_bad_ids
+          schema:
+            type: boolean
+            default: false
+          in: query
+          description: |-
+            If false, if the patch request explicitly lists a BOS component ID that
+            does not exist, it will be considered a fatal error. The patch operation
+            will fail and return a 404 status.
+            If true, the patch request will skip any IDs that do not exist, and
+            patch the remaining items. The response will only include the components
+            that were actually updated.
       description: Update the state for a collection of Components in the BOS database
       tags:
         - v2

--- a/cray/modules/bos/swagger3.json
+++ b/cray/modules/bos/swagger3.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.3",
     "info": {
         "title": "Boot Orchestration Service",
-        "version": "2.30.0",
+        "version": "2.48.0",
         "description": "The Boot Orchestration Service (BOS) provides coordinated provisioning actions\nover defined hardware sets to enable boot, reboot, shutdown, configuration and\nstaging for specified hardware subsets. These provisioning actions apply state\nthrough numerous system management APIs at the request of system administrators\nfor managed product environments.\n\nThe default content type for the BOS API is \"application/json\". Unsuccessful\nAPI calls return a content type of \"application/problem+json\" as per RFC 7807.\n\n## Resources\n\n\n### Session Template\n\nA Session Template sets the operational context of which nodes to operate on for\nany given set of nodes. It is largely comprised of one or more boot\nsets and their associated software configuration.\n\nA Boot Set defines a list of nodes, the image you want to boot/reboot the nodes with,\nkernel parameters to use to boot the nodes, and additional configuration management\nframework actions to apply during node bring up.\n\n### Session\n\nA BOS Session applies a provided action to the nodes defined in a Session Template.\n\n\n## Workflow: Create a New Session\n\n1. Choose the Session Template to use.\n\n  Session Templates which do not belong to a tenant are uniquely identified by their\n  names. All Session Templates that belong to a given tenant are uniquely identified\n  by their names, but may share names with Session Templates that belong to other\n  tenants or that do not belong to a tenant.\n\n  a. List available Session Templates.\n\n    GET /v2/sessiontemplates\n\n  b. Create a new Session Template if desired.\n\n    PUT /v2/sessiontemplate/{template_name}\n\n    If no Session Template exists that satisfies requirements,\n    then create a new Session Template.\n    This Session Template can be used to create a new Session later.\n\n2. Create the Session.\n\n  POST /v2/sessions\n\n  Specify template_name and an operation to create a new Session.\n  The template_name corresponds to the Session Template *name*.\n  A new Session is launched as a result of this call (in the case of\n  /v2/sessions, the option to stage but not begin the Session also exists).\n\n  A limit can also be specified to narrow the scope of the Session. The limit\n  can consist of nodes, groups, or roles in a comma-separated list.\n  Multiple groups are treated as separated by OR, unless \"&\" is added to\n  the start of the component, in which case this becomes an AND.  Components\n  can also be preceded by \"!\" to exclude them.\n\n  Note, the response from a successful Session launch contains *links*.\n  Within *links*, *href* is a string that uniquely identifies the Session.\n  *href* is constructed using the Session Template name and a generated UUID.\n  Use the entire *href* string as the path parameter *session_id*\n  to uniquely identify a Session.\n\n3. Get details on the Session.\n\n  GET /v2/sessions/{session_id}\n\n\n## Interactions with Other APIs\n\n### Configuration Framework Service (CFS)\n\nIf *enable_cfs* is true in a Session Template, then BOS will invoke CFS to\nconfigure the target nodes during *boot* or *reboot* operations.\n\n### Hardware State Manager (HSM)\n\nIn some situations BOS checks HSM to determine if a node has been disabled.\n\n### Image Management Service (IMS)\n\nBOS works in concert with IMS to access boot images.\nAll boot images specified via the Session Template must be available via IMS.\n"
     },
     "servers": [
@@ -226,37 +226,6 @@
                     "minLength": 1,
                     "maxLength": 127
                 }
-            },
-            "ProblemDetails": {
-                "description": "An error response for RFC 7807 problem details.",
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                        "type": "string",
-                        "format": "uri",
-                        "default": "about:blank"
-                    },
-                    "title": {
-                        "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                        "type": "string"
-                    },
-                    "status": {
-                        "description": "HTTP status code",
-                        "type": "integer",
-                        "example": 400
-                    },
-                    "instance": {
-                        "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                        "format": "uri",
-                        "type": "string"
-                    },
-                    "detail": {
-                        "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false
             },
             "SessionLimit": {
                 "type": "string",
@@ -543,6 +512,172 @@
                 "required": [
                     "boot_sets"
                 ]
+            },
+            "V2SessionTemplatePatch": {
+                "type": "object",
+                "description": "Data to update an existing Session Template record.",
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "description": "An optional description for the Session Template.",
+                        "minLength": 1,
+                        "maxLength": 1023
+                    },
+                    "enable_cfs": {
+                        "type": "boolean",
+                        "description": "Whether to enable the Configuration Framework Service (CFS).\n",
+                        "default": true
+                    },
+                    "cfs": {
+                        "type": "object",
+                        "description": "This is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a Boot Set.\n",
+                        "properties": {
+                            "configuration": {
+                                "type": "string",
+                                "description": "The name of configuration to be applied.",
+                                "example": "compute-23.4.0",
+                                "maxLength": 127
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "boot_sets": {
+                        "type": "object",
+                        "description": "Mapping from Boot Set names to Boot Sets.\n\n* Boot Set names must be 1-127 characters in length.\n* Boot Set names must use only letters, digits, periods (.), dashes (-), and underscores (_).\n* Boot Set names must begin and end with a letter or digit.\n",
+                        "minProperties": 1,
+                        "maxProperties": 127,
+                        "additionalProperties": {
+                            "description": "A Boot Set is a collection of nodes defined by an explicit list, their functional\nrole, and their logical groupings. This collection of nodes is associated with one\nset of boot artifacts and optional additional records for configuration and root\nfilesystem provisioning.\n\nA boot set requires at least one of the following fields to be specified:\nnode_list, node_roles_groups, node_groups\n\nIf specified, the name field must match the key mapping to this boot set in the\nboot_sets field of the containing V2SessionTemplate.\n",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "The Boot Set name.\n\n* Boot Set names must use only letters, digits, periods (.), dashes (-), and underscores (_).\n* Boot Set names must begin and end with a letter or digit.\n",
+                                    "example": "compute",
+                                    "minLength": 1,
+                                    "maxLength": 127,
+                                    "pattern": "^[a-zA-Z0-9](?:[-._a-zA-Z0-9]{0,125}[a-zA-Z0-9])?$",
+                                    "writeOnly": true
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "description": "A path identifying the metadata describing the components of the boot image.\nThis could be a URI, URL, etc, depending on the type of the Boot Set.\n",
+                                    "example": "s3://boot-images/9e3c75e1-ac42-42c7-873c-e758048897d6/manifest.json",
+                                    "minLength": 1,
+                                    "maxLength": 4095
+                                },
+                                "cfs": {
+                                    "type": "object",
+                                    "description": "This is the collection of parameters that are passed to the Configuration\nFramework Service when configuration is enabled. Can be set as the global value for\na Session Template, or individually within a Boot Set.\n",
+                                    "properties": {
+                                        "configuration": {
+                                            "type": "string",
+                                            "description": "The name of configuration to be applied.",
+                                            "example": "compute-23.4.0",
+                                            "maxLength": 127
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "type": {
+                                    "type": "string",
+                                    "description": "The MIME type of the metadata describing the components of the boot image. This type controls how BOS processes the path attribute.\n",
+                                    "example": "s3",
+                                    "minLength": 1,
+                                    "maxLength": 127
+                                },
+                                "etag": {
+                                    "type": "string",
+                                    "description": "This is the 'entity tag'. It helps verify the version of metadata describing the components of the boot image we are working with.",
+                                    "example": "1cc4eef4f407bd8a62d7d66ee4b9e9c8",
+                                    "maxLength": 65536
+                                },
+                                "kernel_parameters": {
+                                    "type": "string",
+                                    "description": "The kernel parameters to use to boot the nodes.",
+                                    "example": "console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu=pt ip=dhcp numa_interleave_omit=headless numa_zonelist_order=node oops=panic pageblock_order=14 pcie_ports=native printk.synchronous=y rd.neednet=1 rd.retry=10 rd.shell turbo_boost_limit=999 spire_join_token=${SPIRE_JOIN_TOKEN}",
+                                    "maxLength": 4096
+                                },
+                                "node_list": {
+                                    "type": "array",
+                                    "description": "A node list that is required to have at least one node.\nNodes must be specified by component name (xname). NIDs are not supported.\nIf the reject_nids option is enabled, then Session Template creation or validation will fail if\nany of the boot sets contain a NodeList that appears to contain a NID.\n",
+                                    "minItems": 1,
+                                    "maxItems": 65535,
+                                    "example": [
+                                        "x3000c0s19b1n0",
+                                        "x3000c0s19b2n0"
+                                    ],
+                                    "items": {
+                                        "type": "string",
+                                        "description": "Hardware component name (xname).",
+                                        "example": "x3001c0s39b0n0",
+                                        "minLength": 1,
+                                        "maxLength": 127
+                                    }
+                                },
+                                "node_roles_groups": {
+                                    "type": "array",
+                                    "description": "Node role list. Allows actions against nodes with associated roles.",
+                                    "minItems": 1,
+                                    "maxItems": 1023,
+                                    "example": [
+                                        "Compute",
+                                        "Application"
+                                    ],
+                                    "items": {
+                                        "type": "string",
+                                        "description": "Name of a role that is defined in the Hardware State Manager (HSM).",
+                                        "example": "Compute",
+                                        "minLength": 1,
+                                        "maxLength": 127
+                                    }
+                                },
+                                "node_groups": {
+                                    "type": "array",
+                                    "description": "Node group list. Allows actions against associated nodes by logical groupings.",
+                                    "minItems": 1,
+                                    "maxItems": 4095,
+                                    "items": {
+                                        "type": "string",
+                                        "description": "Name of a user-defined logical group in the Hardware State Manager (HSM).",
+                                        "minLength": 1,
+                                        "maxLength": 127
+                                    }
+                                },
+                                "arch": {
+                                    "type": "string",
+                                    "description": "The node architecture to target. Filters nodes that are not part of matching architecture from being targeted by boot actions. This value should correspond to HSM component 'Arch' field exactly. For reasons of backwards compatibility, all HSM nodes that are of type Unknown are treated as being of type X86.\n",
+                                    "default": "X86",
+                                    "enum": [
+                                        "X86",
+                                        "ARM",
+                                        "Other",
+                                        "Unknown"
+                                    ]
+                                },
+                                "rootfs_provider": {
+                                    "type": "string",
+                                    "description": "The root file system provider.",
+                                    "example": "sbps",
+                                    "minLength": 1,
+                                    "maxLength": 511
+                                },
+                                "rootfs_provider_passthrough": {
+                                    "type": "string",
+                                    "description": "The root file system provider passthrough.\nThese are additional kernel parameters that will be appended to\nthe 'rootfs=<protocol>' kernel parameter\n",
+                                    "example": "sbps:v1:iqn.2023-06.csm.iscsi:_sbps-hsn._tcp.my-system.my-site-domain:300",
+                                    "maxLength": 4096
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "path",
+                                "type"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
             },
             "V2SessionTemplateValidation": {
                 "description": "Message describing errors or incompleteness in a Session Template.\n",
@@ -1299,6 +1434,21 @@
                 },
                 "additionalProperties": false
             },
+            "V2SessionExtendedStatusErrorComponents": {
+                "type": "object",
+                "description": "Summary of Components impacted by an error.",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "description": "The number of Components impacted by the error."
+                    },
+                    "list": {
+                        "type": "string",
+                        "description": "A comma-separated list of the impacted Components.\nIf more than 10 Components are impacted, the first 10 are shown, following by a trailing '...'\n"
+                    }
+                },
+                "additionalProperties": false
+            },
             "V2SessionExtendedStatus": {
                 "type": "object",
                 "description": "Detailed information on the status of a Session.\n",
@@ -1353,7 +1503,22 @@
                     },
                     "error_summary": {
                         "type": "object",
-                        "description": "A summary of the errors currently listed by all Components\n"
+                        "description": "A mapping from error messages to a summary of the impacted Components.\n",
+                        "additionalProperties": {
+                            "type": "object",
+                            "description": "Summary of Components impacted by an error.",
+                            "properties": {
+                                "count": {
+                                    "type": "integer",
+                                    "description": "The number of Components impacted by the error."
+                                },
+                                "list": {
+                                    "type": "string",
+                                    "description": "A comma-separated list of the impacted Components.\nIf more than 10 Components are impacted, the first 10 are shown, following by a trailing '...'\n"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
                     },
                     "timing": {
                         "type": "object",
@@ -1591,7 +1756,15 @@
                     "action": {
                         "type": "string",
                         "description": "A description of the most recent operator/action to impact the Component.",
-                        "maxLength": 1024
+                        "enum": [
+                            "actual_state_cleanup",
+                            "apply_staged",
+                            "newly_discovered",
+                            "powering_off_forcefully",
+                            "powering_off_gracefully",
+                            "powering_on",
+                            "session_setup"
+                        ]
                     },
                     "failed": {
                         "type": "boolean",
@@ -1625,10 +1798,28 @@
                 },
                 "additionalProperties": false
             },
+            "V2ComponentAction": {
+                "type": "string",
+                "description": "A description of the most recent operator/action to impact the Component.",
+                "enum": [
+                    "actual_state_cleanup",
+                    "apply_staged",
+                    "newly_discovered",
+                    "powering_off_forcefully",
+                    "powering_off_gracefully",
+                    "powering_on",
+                    "session_setup"
+                ]
+            },
             "V2ComponentPhase": {
                 "type": "string",
                 "description": "The current phase of the Component in the boot process.",
-                "maxLength": 128
+                "enum": [
+                    "configuring",
+                    "powering_off",
+                    "powering_on",
+                    ""
+                ]
             },
             "V2ComponentStatus": {
                 "description": "Status information for the Component",
@@ -1637,7 +1828,12 @@
                     "phase": {
                         "type": "string",
                         "description": "The current phase of the Component in the boot process.",
-                        "maxLength": 128
+                        "enum": [
+                            "configuring",
+                            "powering_off",
+                            "powering_on",
+                            ""
+                        ]
                     },
                     "status": {
                         "type": "string",
@@ -1819,7 +2015,15 @@
                             "action": {
                                 "type": "string",
                                 "description": "A description of the most recent operator/action to impact the Component.",
-                                "maxLength": 1024
+                                "enum": [
+                                    "actual_state_cleanup",
+                                    "apply_staged",
+                                    "newly_discovered",
+                                    "powering_off_forcefully",
+                                    "powering_off_gracefully",
+                                    "powering_on",
+                                    "session_setup"
+                                ]
                             },
                             "failed": {
                                 "type": "boolean",
@@ -1860,7 +2064,12 @@
                             "phase": {
                                 "type": "string",
                                 "description": "The current phase of the Component in the boot process.",
-                                "maxLength": 128
+                                "enum": [
+                                    "configuring",
+                                    "powering_off",
+                                    "powering_on",
+                                    ""
+                                ]
                             },
                             "status": {
                                 "type": "string",
@@ -2066,7 +2275,15 @@
                             "action": {
                                 "type": "string",
                                 "description": "A description of the most recent operator/action to impact the Component.",
-                                "maxLength": 1024
+                                "enum": [
+                                    "actual_state_cleanup",
+                                    "apply_staged",
+                                    "newly_discovered",
+                                    "powering_off_forcefully",
+                                    "powering_off_gracefully",
+                                    "powering_on",
+                                    "session_setup"
+                                ]
                             },
                             "failed": {
                                 "type": "boolean",
@@ -2107,7 +2324,12 @@
                             "phase": {
                                 "type": "string",
                                 "description": "The current phase of the Component in the boot process.",
-                                "maxLength": 128
+                                "enum": [
+                                    "configuring",
+                                    "powering_off",
+                                    "powering_on",
+                                    ""
+                                ]
                             },
                             "status": {
                                 "type": "string",
@@ -2318,7 +2540,15 @@
                                 "action": {
                                     "type": "string",
                                     "description": "A description of the most recent operator/action to impact the Component.",
-                                    "maxLength": 1024
+                                    "enum": [
+                                        "actual_state_cleanup",
+                                        "apply_staged",
+                                        "newly_discovered",
+                                        "powering_off_forcefully",
+                                        "powering_off_gracefully",
+                                        "powering_on",
+                                        "session_setup"
+                                    ]
                                 },
                                 "failed": {
                                     "type": "boolean",
@@ -2359,7 +2589,12 @@
                                 "phase": {
                                     "type": "string",
                                     "description": "The current phase of the Component in the boot process.",
-                                    "maxLength": 128
+                                    "enum": [
+                                        "configuring",
+                                        "powering_off",
+                                        "powering_on",
+                                        ""
+                                    ]
                                 },
                                 "status": {
                                     "type": "string",
@@ -2569,7 +2804,15 @@
                                 "action": {
                                     "type": "string",
                                     "description": "A description of the most recent operator/action to impact the Component.",
-                                    "maxLength": 1024
+                                    "enum": [
+                                        "actual_state_cleanup",
+                                        "apply_staged",
+                                        "newly_discovered",
+                                        "powering_off_forcefully",
+                                        "powering_off_gracefully",
+                                        "powering_on",
+                                        "session_setup"
+                                    ]
                                 },
                                 "failed": {
                                     "type": "boolean",
@@ -2610,7 +2853,12 @@
                                 "phase": {
                                     "type": "string",
                                     "description": "The current phase of the Component in the boot process.",
-                                    "maxLength": 128
+                                    "enum": [
+                                        "configuring",
+                                        "powering_off",
+                                        "powering_on",
+                                        ""
+                                    ]
                                 },
                                 "status": {
                                     "type": "string",
@@ -2875,7 +3123,15 @@
                                     "action": {
                                         "type": "string",
                                         "description": "A description of the most recent operator/action to impact the Component.",
-                                        "maxLength": 1024
+                                        "enum": [
+                                            "actual_state_cleanup",
+                                            "apply_staged",
+                                            "newly_discovered",
+                                            "powering_off_forcefully",
+                                            "powering_off_gracefully",
+                                            "powering_on",
+                                            "session_setup"
+                                        ]
                                     },
                                     "failed": {
                                         "type": "boolean",
@@ -2916,7 +3172,12 @@
                                     "phase": {
                                         "type": "string",
                                         "description": "The current phase of the Component in the boot process.",
-                                        "maxLength": 128
+                                        "enum": [
+                                            "configuring",
+                                            "powering_off",
+                                            "powering_on",
+                                            ""
+                                        ]
                                     },
                                     "status": {
                                         "type": "string",
@@ -3121,10 +3382,6 @@
                         "minimum": 0,
                         "maximum": 1048576
                     },
-                    "disable_components_on_completion": {
-                        "type": "boolean",
-                        "description": "If true, when a Session has brought a Component to its desired state, that Component will be marked as disabled in BOS.\nIf false, BOS will continue to maintain the state of the nodes declaratively, even after a Session finishes.\n"
-                    },
                     "discovery_frequency": {
                         "type": "integer",
                         "description": "How frequently the BOS discovery agent syncs new Components from HSM (in seconds)",
@@ -3208,6 +3465,136 @@
                 "additionalProperties": true,
                 "minProperties": 1,
                 "maxProperties": 1024
+            },
+            "ProblemDetails": {
+                "description": "An error response for RFC 7807 problem details.",
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                        "type": "string",
+                        "format": "uri",
+                        "default": "about:blank"
+                    },
+                    "title": {
+                        "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "HTTP status code",
+                        "type": "integer",
+                        "example": 400
+                    },
+                    "instance": {
+                        "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                        "format": "uri",
+                        "type": "string"
+                    },
+                    "detail": {
+                        "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ProblemAlreadyExists": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "enum": [
+                            "The resource to be created already exists"
+                        ],
+                        "default": "The resource to be created already exists"
+                    },
+                    "status": {
+                        "type": "integer",
+                        "enum": [
+                            409
+                        ],
+                        "default": 409
+                    }
+                },
+                "additionalProperties": true
+            },
+            "ProblemBadRequest": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "enum": [
+                            "Bad Request"
+                        ],
+                        "default": "Bad Request"
+                    },
+                    "status": {
+                        "type": "integer",
+                        "enum": [
+                            400
+                        ],
+                        "default": 400
+                    }
+                },
+                "additionalProperties": true
+            },
+            "ProblemResourceNotFound": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "enum": [
+                            "The resource was not found"
+                        ],
+                        "default": "The resource was not found"
+                    },
+                    "status": {
+                        "type": "integer",
+                        "enum": [
+                            404
+                        ],
+                        "default": 404
+                    }
+                },
+                "additionalProperties": true
+            },
+            "ProblemUpdateConflict": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "enum": [
+                            "The update was not allowed due to a conflict"
+                        ],
+                        "default": "The update was not allowed due to a conflict"
+                    }
+                },
+                "additionalProperties": true
+            },
+            "ProblemServiceUnavailable": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "enum": [
+                            "Service Unavailable"
+                        ],
+                        "default": "Service Unavailable"
+                    }
+                },
+                "additionalProperties": true
+            },
+            "ProblemInternalError": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "enum": [
+                            "An Internal Server Error occurred handling the request"
+                        ],
+                        "default": "An Internal Server Error occurred handling the request"
+                    }
+                },
+                "additionalProperties": true
             }
         },
         "requestBodies": {
@@ -3444,7 +3831,15 @@
                                         "action": {
                                             "type": "string",
                                             "description": "A description of the most recent operator/action to impact the Component.",
-                                            "maxLength": 1024
+                                            "enum": [
+                                                "actual_state_cleanup",
+                                                "apply_staged",
+                                                "newly_discovered",
+                                                "powering_off_forcefully",
+                                                "powering_off_gracefully",
+                                                "powering_on",
+                                                "session_setup"
+                                            ]
                                         },
                                         "failed": {
                                             "type": "boolean",
@@ -3485,7 +3880,12 @@
                                         "phase": {
                                             "type": "string",
                                             "description": "The current phase of the Component in the boot process.",
-                                            "maxLength": 128
+                                            "enum": [
+                                                "configuring",
+                                                "powering_off",
+                                                "powering_on",
+                                                ""
+                                            ]
                                         },
                                         "status": {
                                             "type": "string",
@@ -3702,7 +4102,15 @@
                                             "action": {
                                                 "type": "string",
                                                 "description": "A description of the most recent operator/action to impact the Component.",
-                                                "maxLength": 1024
+                                                "enum": [
+                                                    "actual_state_cleanup",
+                                                    "apply_staged",
+                                                    "newly_discovered",
+                                                    "powering_off_forcefully",
+                                                    "powering_off_gracefully",
+                                                    "powering_on",
+                                                    "session_setup"
+                                                ]
                                             },
                                             "failed": {
                                                 "type": "boolean",
@@ -3743,7 +4151,12 @@
                                             "phase": {
                                                 "type": "string",
                                                 "description": "The current phase of the Component in the boot process.",
-                                                "maxLength": 128
+                                                "enum": [
+                                                    "configuring",
+                                                    "powering_off",
+                                                    "powering_on",
+                                                    ""
+                                                ]
                                             },
                                             "status": {
                                                 "type": "string",
@@ -3848,10 +4261,6 @@
                                     "example": 1,
                                     "minimum": 0,
                                     "maximum": 1048576
-                                },
-                                "disable_components_on_completion": {
-                                    "type": "boolean",
-                                    "description": "If true, when a Session has brought a Component to its desired state, that Component will be marked as disabled in BOS.\nIf false, BOS will continue to maintain the state of the nodes declaratively, even after a Session finishes.\n"
                                 },
                                 "discovery_frequency": {
                                     "type": "integer",
@@ -4792,7 +5201,22 @@
                                 },
                                 "error_summary": {
                                     "type": "object",
-                                    "description": "A summary of the errors currently listed by all Components\n"
+                                    "description": "A mapping from error messages to a summary of the impacted Components.\n",
+                                    "additionalProperties": {
+                                        "type": "object",
+                                        "description": "Summary of Components impacted by an error.",
+                                        "properties": {
+                                            "count": {
+                                                "type": "integer",
+                                                "description": "The number of Components impacted by the error."
+                                            },
+                                            "list": {
+                                                "type": "string",
+                                                "description": "A comma-separated list of the impacted Components.\nIf more than 10 Components are impacted, the first 10 are shown, following by a trailing '...'\n"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
                                 },
                                 "timing": {
                                     "type": "object",
@@ -4993,7 +5417,15 @@
                                         "action": {
                                             "type": "string",
                                             "description": "A description of the most recent operator/action to impact the Component.",
-                                            "maxLength": 1024
+                                            "enum": [
+                                                "actual_state_cleanup",
+                                                "apply_staged",
+                                                "newly_discovered",
+                                                "powering_off_forcefully",
+                                                "powering_off_gracefully",
+                                                "powering_on",
+                                                "session_setup"
+                                            ]
                                         },
                                         "failed": {
                                             "type": "boolean",
@@ -5034,7 +5466,12 @@
                                         "phase": {
                                             "type": "string",
                                             "description": "The current phase of the Component in the boot process.",
-                                            "maxLength": 128
+                                            "enum": [
+                                                "configuring",
+                                                "powering_off",
+                                                "powering_on",
+                                                ""
+                                            ]
                                         },
                                         "status": {
                                             "type": "string",
@@ -5250,7 +5687,15 @@
                                             "action": {
                                                 "type": "string",
                                                 "description": "A description of the most recent operator/action to impact the Component.",
-                                                "maxLength": 1024
+                                                "enum": [
+                                                    "actual_state_cleanup",
+                                                    "apply_staged",
+                                                    "newly_discovered",
+                                                    "powering_off_forcefully",
+                                                    "powering_off_gracefully",
+                                                    "powering_on",
+                                                    "session_setup"
+                                                ]
                                             },
                                             "failed": {
                                                 "type": "boolean",
@@ -5291,7 +5736,12 @@
                                             "phase": {
                                                 "type": "string",
                                                 "description": "The current phase of the Component in the boot process.",
-                                                "maxLength": 128
+                                                "enum": [
+                                                    "configuring",
+                                                    "powering_off",
+                                                    "powering_on",
+                                                    ""
+                                                ]
                                             },
                                             "status": {
                                                 "type": "string",
@@ -5430,10 +5880,6 @@
                                     "minimum": 0,
                                     "maximum": 1048576
                                 },
-                                "disable_components_on_completion": {
-                                    "type": "boolean",
-                                    "description": "If true, when a Session has brought a Component to its desired state, that Component will be marked as disabled in BOS.\nIf false, BOS will continue to maintain the state of the nodes declaratively, even after a Session finishes.\n"
-                                },
                                 "discovery_frequency": {
                                     "type": "integer",
                                     "description": "How frequently the BOS discovery agent syncs new Components from HSM (in seconds)",
@@ -5526,35 +5972,59 @@
                 "content": {
                     "application/problem+json": {
                         "schema": {
-                            "description": "An error response for RFC 7807 problem details.",
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                    "type": "string",
-                                    "format": "uri",
-                                    "default": "about:blank"
+                            "allOf": [
+                                {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
                                 },
-                                "title": {
-                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                    "type": "string"
-                                },
-                                "status": {
-                                    "description": "HTTP status code",
-                                    "type": "integer",
-                                    "example": 400
-                                },
-                                "instance": {
-                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                    "format": "uri",
-                                    "type": "string"
-                                },
-                                "detail": {
-                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                    "type": "string"
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string",
+                                            "enum": [
+                                                "The resource to be created already exists"
+                                            ],
+                                            "default": "The resource to be created already exists"
+                                        },
+                                        "status": {
+                                            "type": "integer",
+                                            "enum": [
+                                                409
+                                            ],
+                                            "default": 409
+                                        }
+                                    },
+                                    "additionalProperties": true
                                 }
-                            },
-                            "additionalProperties": false
+                            ]
                         }
                     }
                 }
@@ -5564,111 +6034,59 @@
                 "content": {
                     "application/problem+json": {
                         "schema": {
-                            "description": "An error response for RFC 7807 problem details.",
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                    "type": "string",
-                                    "format": "uri",
-                                    "default": "about:blank"
+                            "allOf": [
+                                {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
                                 },
-                                "title": {
-                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                    "type": "string"
-                                },
-                                "status": {
-                                    "description": "HTTP status code",
-                                    "type": "integer",
-                                    "example": 400
-                                },
-                                "instance": {
-                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                    "format": "uri",
-                                    "type": "string"
-                                },
-                                "detail": {
-                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                    "type": "string"
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string",
+                                            "enum": [
+                                                "Bad Request"
+                                            ],
+                                            "default": "Bad Request"
+                                        },
+                                        "status": {
+                                            "type": "integer",
+                                            "enum": [
+                                                400
+                                            ],
+                                            "default": 400
+                                        }
+                                    },
+                                    "additionalProperties": true
                                 }
-                            },
-                            "additionalProperties": false
-                        }
-                    }
-                }
-            },
-            "BadRequestOrMultiTenancyNotSupported": {
-                "description": "Multi-tenancy is not supported for this request.\nIf no tenant was specified, then the request was bad for another reason.\n",
-                "content": {
-                    "application/problem+json": {
-                        "schema": {
-                            "description": "An error response for RFC 7807 problem details.",
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                    "type": "string",
-                                    "format": "uri",
-                                    "default": "about:blank"
-                                },
-                                "title": {
-                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                    "type": "string"
-                                },
-                                "status": {
-                                    "description": "HTTP status code",
-                                    "type": "integer",
-                                    "example": 400
-                                },
-                                "instance": {
-                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                    "format": "uri",
-                                    "type": "string"
-                                },
-                                "detail": {
-                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    }
-                }
-            },
-            "MultiTenancyNotSupported": {
-                "description": "Multi-tenancy is not supported for this BOS request.",
-                "content": {
-                    "application/problem+json": {
-                        "schema": {
-                            "description": "An error response for RFC 7807 problem details.",
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                    "type": "string",
-                                    "format": "uri",
-                                    "default": "about:blank"
-                                },
-                                "title": {
-                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                    "type": "string"
-                                },
-                                "status": {
-                                    "description": "HTTP status code",
-                                    "type": "integer",
-                                    "example": 400
-                                },
-                                "instance": {
-                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                    "format": "uri",
-                                    "type": "string"
-                                },
-                                "detail": {
-                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
+                            ]
                         }
                     }
                 }
@@ -5678,35 +6096,59 @@
                 "content": {
                     "application/problem+json": {
                         "schema": {
-                            "description": "An error response for RFC 7807 problem details.",
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                    "type": "string",
-                                    "format": "uri",
-                                    "default": "about:blank"
+                            "allOf": [
+                                {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
                                 },
-                                "title": {
-                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                    "type": "string"
-                                },
-                                "status": {
-                                    "description": "HTTP status code",
-                                    "type": "integer",
-                                    "example": 400
-                                },
-                                "instance": {
-                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                    "format": "uri",
-                                    "type": "string"
-                                },
-                                "detail": {
-                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                    "type": "string"
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string",
+                                            "enum": [
+                                                "The resource was not found"
+                                            ],
+                                            "default": "The resource was not found"
+                                        },
+                                        "status": {
+                                            "type": "integer",
+                                            "enum": [
+                                                404
+                                            ],
+                                            "default": 404
+                                        }
+                                    },
+                                    "additionalProperties": true
                                 }
-                            },
-                            "additionalProperties": false
+                            ]
                         }
                     }
                 }
@@ -5716,35 +6158,52 @@
                 "content": {
                     "application/problem+json": {
                         "schema": {
-                            "description": "An error response for RFC 7807 problem details.",
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                    "type": "string",
-                                    "format": "uri",
-                                    "default": "about:blank"
+                            "allOf": [
+                                {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
                                 },
-                                "title": {
-                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                    "type": "string"
-                                },
-                                "status": {
-                                    "description": "HTTP status code",
-                                    "type": "integer",
-                                    "example": 400
-                                },
-                                "instance": {
-                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                    "format": "uri",
-                                    "type": "string"
-                                },
-                                "detail": {
-                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                    "type": "string"
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string",
+                                            "enum": [
+                                                "The update was not allowed due to a conflict"
+                                            ],
+                                            "default": "The update was not allowed due to a conflict"
+                                        }
+                                    },
+                                    "additionalProperties": true
                                 }
-                            },
-                            "additionalProperties": false
+                            ]
                         }
                     }
                 }
@@ -5754,35 +6213,52 @@
                 "content": {
                     "application/problem+json": {
                         "schema": {
-                            "description": "An error response for RFC 7807 problem details.",
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                    "type": "string",
-                                    "format": "uri",
-                                    "default": "about:blank"
+                            "allOf": [
+                                {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
                                 },
-                                "title": {
-                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                    "type": "string"
-                                },
-                                "status": {
-                                    "description": "HTTP status code",
-                                    "type": "integer",
-                                    "example": 400
-                                },
-                                "instance": {
-                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                    "format": "uri",
-                                    "type": "string"
-                                },
-                                "detail": {
-                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                    "type": "string"
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string",
+                                            "enum": [
+                                                "Service Unavailable"
+                                            ],
+                                            "default": "Service Unavailable"
+                                        }
+                                    },
+                                    "additionalProperties": true
                                 }
-                            },
-                            "additionalProperties": false
+                            ]
                         }
                     }
                 }
@@ -5792,35 +6268,52 @@
                 "content": {
                     "application/problem+json": {
                         "schema": {
-                            "description": "An error response for RFC 7807 problem details.",
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                    "type": "string",
-                                    "format": "uri",
-                                    "default": "about:blank"
+                            "allOf": [
+                                {
+                                    "description": "An error response for RFC 7807 problem details.",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                            "type": "string",
+                                            "format": "uri",
+                                            "default": "about:blank"
+                                        },
+                                        "title": {
+                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "HTTP status code",
+                                            "type": "integer",
+                                            "example": 400
+                                        },
+                                        "instance": {
+                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                            "format": "uri",
+                                            "type": "string"
+                                        },
+                                        "detail": {
+                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
                                 },
-                                "title": {
-                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                    "type": "string"
-                                },
-                                "status": {
-                                    "description": "HTTP status code",
-                                    "type": "integer",
-                                    "example": 400
-                                },
-                                "instance": {
-                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                    "format": "uri",
-                                    "type": "string"
-                                },
-                                "detail": {
-                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                    "type": "string"
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string",
+                                            "enum": [
+                                                "An Internal Server Error occurred handling the request"
+                                            ],
+                                            "default": "An Internal Server Error occurred handling the request"
+                                        }
+                                    },
+                                    "additionalProperties": true
                                 }
-                            },
-                            "additionalProperties": false
+                            ]
                         }
                     }
                 }
@@ -5983,35 +6476,52 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "An Internal Server Error occurred handling the request"
+                                                    ],
+                                                    "default": "An Internal Server Error occurred handling the request"
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -6078,35 +6588,52 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "An Internal Server Error occurred handling the request"
+                                                    ],
+                                                    "default": "An Internal Server Error occurred handling the request"
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -6150,35 +6677,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -6188,35 +6739,52 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Service Unavailable"
+                                                    ],
+                                                    "default": "Service Unavailable"
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -6521,35 +7089,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource was not found"
+                                                    ],
+                                                    "default": "The resource was not found"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        404
+                                                    ],
+                                                    "default": 404
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -6811,35 +7403,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource was not found"
+                                                    ],
+                                                    "default": "The resource was not found"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        404
+                                                    ],
+                                                    "default": 404
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -7282,35 +7898,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -7333,24 +7973,8 @@
                         "application/json": {
                             "schema": {
                                 "type": "object",
-                                "description": "A Session Template object represents a collection of resources and metadata.\nA Session Template is used to create a Session which applies the data to\ngroup of Components.\n\n## Link Relationships\n\n* self : The Session Template object\n",
+                                "description": "Data to update an existing Session Template record.",
                                 "properties": {
-                                    "name": {
-                                        "type": "string",
-                                        "minLength": 1,
-                                        "maxLength": 127,
-                                        "pattern": "^[a-zA-Z0-9](?:[-._a-zA-Z0-9]{0,125}[a-zA-Z0-9])?$",
-                                        "readOnly": true,
-                                        "description": "Name of the Session Template.\n\nNames must:\n* Use only letters, digits, periods (.), dashes (-), and underscores (_).\n* Begin and end with a letter or digit.\n",
-                                        "example": "cle-1.0.0"
-                                    },
-                                    "tenant": {
-                                        "type": "string",
-                                        "description": "Name of the tenant that owns this resource. Only used in environments\nwith multi-tenancy enabled. An empty string or null value means the resource\nis not owned by a tenant. The absence of this field from a resource indicates\nthe same.\n",
-                                        "nullable": true,
-                                        "readOnly": true,
-                                        "maxLength": 127
-                                    },
                                     "description": {
                                         "type": "string",
                                         "description": "An optional description for the Session Template.",
@@ -7509,30 +8133,9 @@
                                                 "type"
                                             ]
                                         }
-                                    },
-                                    "links": {
-                                        "description": "List of links to other resources",
-                                        "type": "array",
-                                        "readOnly": true,
-                                        "items": {
-                                            "description": "Link to other resources",
-                                            "type": "object",
-                                            "properties": {
-                                                "href": {
-                                                    "type": "string"
-                                                },
-                                                "rel": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "additionalProperties": false
-                                        }
                                     }
                                 },
-                                "additionalProperties": false,
-                                "required": [
-                                    "boot_sets"
-                                ]
+                                "additionalProperties": false
                             }
                         }
                     }
@@ -7753,35 +8356,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -7791,35 +8418,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource was not found"
+                                                    ],
+                                                    "default": "The resource was not found"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        404
+                                                    ],
+                                                    "default": 404
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -7844,35 +8495,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource was not found"
+                                                    ],
+                                                    "default": "The resource was not found"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        404
+                                                    ],
+                                                    "default": 404
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -8299,35 +8974,121 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "The resource to be created already exists",
+                        "content": {
+                            "application/problem+json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource to be created already exists"
+                                                    ],
+                                                    "default": "The resource to be created already exists"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        409
+                                                    ],
+                                                    "default": 409
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -8556,35 +9317,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -8740,35 +9525,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource was not found"
+                                                    ],
+                                                    "default": "The resource was not found"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        404
+                                                    ],
+                                                    "default": 404
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -8948,35 +9757,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -8986,35 +9819,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource was not found"
+                                                    ],
+                                                    "default": "The resource was not found"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        404
+                                                    ],
+                                                    "default": 404
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -9039,35 +9896,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource was not found"
+                                                    ],
+                                                    "default": "The resource was not found"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        404
+                                                    ],
+                                                    "default": 404
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -9172,7 +10053,22 @@
                                         },
                                         "error_summary": {
                                             "type": "object",
-                                            "description": "A summary of the errors currently listed by all Components\n"
+                                            "description": "A mapping from error messages to a summary of the impacted Components.\n",
+                                            "additionalProperties": {
+                                                "type": "object",
+                                                "description": "Summary of Components impacted by an error.",
+                                                "properties": {
+                                                    "count": {
+                                                        "type": "integer",
+                                                        "description": "The number of Components impacted by the error."
+                                                    },
+                                                    "list": {
+                                                        "type": "string",
+                                                        "description": "A comma-separated list of the impacted Components.\nIf more than 10 Components are impacted, the first 10 are shown, following by a trailing '...'\n"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            }
                                         },
                                         "timing": {
                                             "type": "object",
@@ -9207,35 +10103,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource was not found"
+                                                    ],
+                                                    "default": "The resource was not found"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        404
+                                                    ],
+                                                    "default": 404
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -9362,35 +10282,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource was not found"
+                                                    ],
+                                                    "default": "The resource was not found"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        404
+                                                    ],
+                                                    "default": 404
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -9466,7 +10410,12 @@
                         "schema": {
                             "type": "string",
                             "description": "The current phase of the Component in the boot process.",
-                            "maxLength": 128
+                            "enum": [
+                                "configuring",
+                                "powering_off",
+                                "powering_on",
+                                ""
+                            ]
                         },
                         "in": "query",
                         "description": "Retrieve the Components in the given phase."
@@ -9479,6 +10428,27 @@
                         },
                         "in": "query",
                         "description": "Retrieve the Components with the given status."
+                    },
+                    {
+                        "name": "start_after_id",
+                        "schema": {
+                            "type": "string",
+                            "description": "The Component's ID. (e.g. xname for hardware Components)",
+                            "minLength": 1,
+                            "maxLength": 127
+                        },
+                        "in": "query",
+                        "description": "Begin listing Components after the specified ID. Used for paging."
+                    },
+                    {
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 1048576
+                        },
+                        "in": "query",
+                        "description": "Maximum number of Components to include in response. Used for paging. 0 means no limit\n(which is the same as not specifying this parameter)."
                     }
                 ],
                 "description": "Retrieve the full collection of Components in the form of a\nComponentArray. Full results can also be filtered by query\nparameters. Only the first filter parameter of each type is\nused and the parameters are applied in an AND fashion.\nIf the collection is empty or the filters have no match, an\nempty array is returned.",
@@ -9663,7 +10633,15 @@
                                                     "action": {
                                                         "type": "string",
                                                         "description": "A description of the most recent operator/action to impact the Component.",
-                                                        "maxLength": 1024
+                                                        "enum": [
+                                                            "actual_state_cleanup",
+                                                            "apply_staged",
+                                                            "newly_discovered",
+                                                            "powering_off_forcefully",
+                                                            "powering_off_gracefully",
+                                                            "powering_on",
+                                                            "session_setup"
+                                                        ]
                                                     },
                                                     "failed": {
                                                         "type": "boolean",
@@ -9704,7 +10682,12 @@
                                                     "phase": {
                                                         "type": "string",
                                                         "description": "The current phase of the Component in the boot process.",
-                                                        "maxLength": 128
+                                                        "enum": [
+                                                            "configuring",
+                                                            "powering_off",
+                                                            "powering_on",
+                                                            ""
+                                                        ]
                                                     },
                                                     "status": {
                                                         "type": "string",
@@ -9752,35 +10735,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -9972,7 +10979,15 @@
                                                 "action": {
                                                     "type": "string",
                                                     "description": "A description of the most recent operator/action to impact the Component.",
-                                                    "maxLength": 1024
+                                                    "enum": [
+                                                        "actual_state_cleanup",
+                                                        "apply_staged",
+                                                        "newly_discovered",
+                                                        "powering_off_forcefully",
+                                                        "powering_off_gracefully",
+                                                        "powering_on",
+                                                        "session_setup"
+                                                    ]
                                                 },
                                                 "failed": {
                                                     "type": "boolean",
@@ -10013,7 +11028,12 @@
                                                 "phase": {
                                                     "type": "string",
                                                     "description": "The current phase of the Component in the boot process.",
-                                                    "maxLength": 128
+                                                    "enum": [
+                                                        "configuring",
+                                                        "powering_off",
+                                                        "powering_on",
+                                                        ""
+                                                    ]
                                                 },
                                                 "status": {
                                                     "type": "string",
@@ -10233,7 +11253,15 @@
                                                     "action": {
                                                         "type": "string",
                                                         "description": "A description of the most recent operator/action to impact the Component.",
-                                                        "maxLength": 1024
+                                                        "enum": [
+                                                            "actual_state_cleanup",
+                                                            "apply_staged",
+                                                            "newly_discovered",
+                                                            "powering_off_forcefully",
+                                                            "powering_off_gracefully",
+                                                            "powering_on",
+                                                            "session_setup"
+                                                        ]
                                                     },
                                                     "failed": {
                                                         "type": "boolean",
@@ -10274,7 +11302,12 @@
                                                     "phase": {
                                                         "type": "string",
                                                         "description": "The current phase of the Component in the boot process.",
-                                                        "maxLength": 128
+                                                        "enum": [
+                                                            "configuring",
+                                                            "powering_off",
+                                                            "powering_on",
+                                                            ""
+                                                        ]
                                                     },
                                                     "status": {
                                                         "type": "string",
@@ -10322,35 +11355,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -10359,6 +11416,17 @@
             },
             "post": {
                 "summary": "Update a collection of Components",
+                "parameters": [
+                    {
+                        "name": "skip_bad_ids",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "in": "query",
+                        "description": "If false, if the patch request explicitly lists a BOS component ID that\ndoes not exist, it will be considered a fatal error. The patch operation\nwill fail and return a 404 status.\nIf true, the patch request will skip any IDs that do not exist, and\npatch the remaining items. The response will only include the components\nthat were actually updated."
+                    }
+                ],
                 "description": "Update the state for a collection of Components in the BOS database",
                 "tags": [
                     "v2",
@@ -10552,7 +11620,15 @@
                                                     "action": {
                                                         "type": "string",
                                                         "description": "A description of the most recent operator/action to impact the Component.",
-                                                        "maxLength": 1024
+                                                        "enum": [
+                                                            "actual_state_cleanup",
+                                                            "apply_staged",
+                                                            "newly_discovered",
+                                                            "powering_off_forcefully",
+                                                            "powering_off_gracefully",
+                                                            "powering_on",
+                                                            "session_setup"
+                                                        ]
                                                     },
                                                     "failed": {
                                                         "type": "boolean",
@@ -10593,7 +11669,12 @@
                                                     "phase": {
                                                         "type": "string",
                                                         "description": "The current phase of the Component in the boot process.",
-                                                        "maxLength": 128
+                                                        "enum": [
+                                                            "configuring",
+                                                            "powering_off",
+                                                            "powering_on",
+                                                            ""
+                                                        ]
                                                     },
                                                     "status": {
                                                         "type": "string",
@@ -10641,35 +11722,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -10679,35 +11784,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource was not found"
+                                                    ],
+                                                    "default": "The resource was not found"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        404
+                                                    ],
+                                                    "default": 404
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -10923,7 +12052,15 @@
                                                 "action": {
                                                     "type": "string",
                                                     "description": "A description of the most recent operator/action to impact the Component.",
-                                                    "maxLength": 1024
+                                                    "enum": [
+                                                        "actual_state_cleanup",
+                                                        "apply_staged",
+                                                        "newly_discovered",
+                                                        "powering_off_forcefully",
+                                                        "powering_off_gracefully",
+                                                        "powering_on",
+                                                        "session_setup"
+                                                    ]
                                                 },
                                                 "failed": {
                                                     "type": "boolean",
@@ -10964,7 +12101,12 @@
                                                 "phase": {
                                                     "type": "string",
                                                     "description": "The current phase of the Component in the boot process.",
-                                                    "maxLength": 128
+                                                    "enum": [
+                                                        "configuring",
+                                                        "powering_off",
+                                                        "powering_on",
+                                                        ""
+                                                    ]
                                                 },
                                                 "status": {
                                                     "type": "string",
@@ -11011,35 +12153,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -11049,35 +12215,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource was not found"
+                                                    ],
+                                                    "default": "The resource was not found"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        404
+                                                    ],
+                                                    "default": 404
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -11265,7 +12455,15 @@
                                             "action": {
                                                 "type": "string",
                                                 "description": "A description of the most recent operator/action to impact the Component.",
-                                                "maxLength": 1024
+                                                "enum": [
+                                                    "actual_state_cleanup",
+                                                    "apply_staged",
+                                                    "newly_discovered",
+                                                    "powering_off_forcefully",
+                                                    "powering_off_gracefully",
+                                                    "powering_on",
+                                                    "session_setup"
+                                                ]
                                             },
                                             "failed": {
                                                 "type": "boolean",
@@ -11306,7 +12504,12 @@
                                             "phase": {
                                                 "type": "string",
                                                 "description": "The current phase of the Component in the boot process.",
-                                                "maxLength": 128
+                                                "enum": [
+                                                    "configuring",
+                                                    "powering_off",
+                                                    "powering_on",
+                                                    ""
+                                                ]
                                             },
                                             "status": {
                                                 "type": "string",
@@ -11520,7 +12723,15 @@
                                                 "action": {
                                                     "type": "string",
                                                     "description": "A description of the most recent operator/action to impact the Component.",
-                                                    "maxLength": 1024
+                                                    "enum": [
+                                                        "actual_state_cleanup",
+                                                        "apply_staged",
+                                                        "newly_discovered",
+                                                        "powering_off_forcefully",
+                                                        "powering_off_gracefully",
+                                                        "powering_on",
+                                                        "session_setup"
+                                                    ]
                                                 },
                                                 "failed": {
                                                     "type": "boolean",
@@ -11561,7 +12772,12 @@
                                                 "phase": {
                                                     "type": "string",
                                                     "description": "The current phase of the Component in the boot process.",
-                                                    "maxLength": 128
+                                                    "enum": [
+                                                        "configuring",
+                                                        "powering_off",
+                                                        "powering_on",
+                                                        ""
+                                                    ]
                                                 },
                                                 "status": {
                                                     "type": "string",
@@ -11608,35 +12824,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -11824,7 +13064,15 @@
                                             "action": {
                                                 "type": "string",
                                                 "description": "A description of the most recent operator/action to impact the Component.",
-                                                "maxLength": 1024
+                                                "enum": [
+                                                    "actual_state_cleanup",
+                                                    "apply_staged",
+                                                    "newly_discovered",
+                                                    "powering_off_forcefully",
+                                                    "powering_off_gracefully",
+                                                    "powering_on",
+                                                    "session_setup"
+                                                ]
                                             },
                                             "failed": {
                                                 "type": "boolean",
@@ -11865,7 +13113,12 @@
                                             "phase": {
                                                 "type": "string",
                                                 "description": "The current phase of the Component in the boot process.",
-                                                "maxLength": 128
+                                                "enum": [
+                                                    "configuring",
+                                                    "powering_off",
+                                                    "powering_on",
+                                                    ""
+                                                ]
                                             },
                                             "status": {
                                                 "type": "string",
@@ -12079,7 +13332,15 @@
                                                 "action": {
                                                     "type": "string",
                                                     "description": "A description of the most recent operator/action to impact the Component.",
-                                                    "maxLength": 1024
+                                                    "enum": [
+                                                        "actual_state_cleanup",
+                                                        "apply_staged",
+                                                        "newly_discovered",
+                                                        "powering_off_forcefully",
+                                                        "powering_off_gracefully",
+                                                        "powering_on",
+                                                        "session_setup"
+                                                    ]
                                                 },
                                                 "failed": {
                                                     "type": "boolean",
@@ -12120,7 +13381,12 @@
                                                 "phase": {
                                                     "type": "string",
                                                     "description": "The current phase of the Component in the boot process.",
-                                                    "maxLength": 128
+                                                    "enum": [
+                                                        "configuring",
+                                                        "powering_off",
+                                                        "powering_on",
+                                                        ""
+                                                    ]
                                                 },
                                                 "status": {
                                                     "type": "string",
@@ -12167,35 +13433,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -12205,35 +13495,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource was not found"
+                                                    ],
+                                                    "default": "The resource was not found"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        404
+                                                    ],
+                                                    "default": 404
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -12243,35 +13557,52 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The update was not allowed due to a conflict"
+                                                    ],
+                                                    "default": "The update was not allowed due to a conflict"
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -12297,35 +13628,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "The resource was not found"
+                                                    ],
+                                                    "default": "The resource was not found"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        404
+                                                    ],
+                                                    "default": 404
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -12436,35 +13791,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -12530,10 +13909,6 @@
                                             "example": 1,
                                             "minimum": 0,
                                             "maximum": 1048576
-                                        },
-                                        "disable_components_on_completion": {
-                                            "type": "boolean",
-                                            "description": "If true, when a Session has brought a Component to its desired state, that Component will be marked as disabled in BOS.\nIf false, BOS will continue to maintain the state of the nodes declaratively, even after a Session finishes.\n"
                                         },
                                         "discovery_frequency": {
                                             "type": "integer",
@@ -12683,10 +14058,6 @@
                                         "minimum": 0,
                                         "maximum": 1048576
                                     },
-                                    "disable_components_on_completion": {
-                                        "type": "boolean",
-                                        "description": "If true, when a Session has brought a Component to its desired state, that Component will be marked as disabled in BOS.\nIf false, BOS will continue to maintain the state of the nodes declaratively, even after a Session finishes.\n"
-                                    },
                                     "discovery_frequency": {
                                         "type": "integer",
                                         "description": "How frequently the BOS discovery agent syncs new Components from HSM (in seconds)",
@@ -12824,10 +14195,6 @@
                                             "minimum": 0,
                                             "maximum": 1048576
                                         },
-                                        "disable_components_on_completion": {
-                                            "type": "boolean",
-                                            "description": "If true, when a Session has brought a Component to its desired state, that Component will be marked as disabled in BOS.\nIf false, BOS will continue to maintain the state of the nodes declaratively, even after a Session finishes.\n"
-                                        },
                                         "discovery_frequency": {
                                             "type": "integer",
                                             "description": "How frequently the BOS discovery agent syncs new Components from HSM (in seconds)",
@@ -12920,35 +14287,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }
@@ -13015,35 +14406,59 @@
                         "content": {
                             "application/problem+json": {
                                 "schema": {
-                                    "description": "An error response for RFC 7807 problem details.",
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
-                                            "type": "string",
-                                            "format": "uri",
-                                            "default": "about:blank"
+                                    "allOf": [
+                                        {
+                                            "description": "An error response for RFC 7807 problem details.",
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "description": "Relative URI reference to the type of problem which includes human\nreadable documentation.\n",
+                                                    "type": "string",
+                                                    "format": "uri",
+                                                    "default": "about:blank"
+                                                },
+                                                "title": {
+                                                    "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "HTTP status code",
+                                                    "type": "integer",
+                                                    "example": 400
+                                                },
+                                                "instance": {
+                                                    "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "detail": {
+                                                    "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": false
                                         },
-                                        "title": {
-                                            "description": "Short, human-readable summary of the problem, should not change by\noccurrence.\n",
-                                            "type": "string"
-                                        },
-                                        "status": {
-                                            "description": "HTTP status code",
-                                            "type": "integer",
-                                            "example": 400
-                                        },
-                                        "instance": {
-                                            "description": "A relative URI reference that identifies the specific occurrence of\nthe problem\n",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "detail": {
-                                            "description": "A human-readable explanation specific to this occurrence of the\nproblem. Focus on helping correct the problem, rather than giving\ndebugging information.\n",
-                                            "type": "string"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Bad Request"
+                                                    ],
+                                                    "default": "Bad Request"
+                                                },
+                                                "status": {
+                                                    "type": "integer",
+                                                    "enum": [
+                                                        400
+                                                    ],
+                                                    "default": 400
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    ]
                                 }
                             }
                         }


### PR DESCRIPTION
This updates the BOS API spec to the latest from the BOS repo, with the most notable change being the removal of the `disable_components_on_completion` option (associated with [this BOS PR](https://github.com/Cray-HPE/bos/pull/541))