### PR TITLE
Fix zone name length

### DIFF
--- a/cray/modules/rrs/swagger.yaml
+++ b/cray/modules/rrs/swagger.yaml
@@ -542,7 +542,7 @@ components:
       type: string
       description: Unique identifier name for the zone
       minLength: 1
-      maxLength: 1000
+      maxLength: 63
     ZonesResponse:
       type: object
       required: [Zones]

--- a/cray/modules/rrs/swagger3.json
+++ b/cray/modules/rrs/swagger3.json
@@ -68,7 +68,7 @@
                                                         "type": "string",
                                                         "description": "Unique identifier name for the zone",
                                                         "minLength": 1,
-                                                        "maxLength": 1000
+                                                        "maxLength": 63
                                                     },
                                                     "Kubernetes_Topology_Zone": {
                                                         "type": "object",
@@ -281,7 +281,7 @@
                             "type": "string",
                             "description": "Unique identifier name for the zone",
                             "minLength": 1,
-                            "maxLength": 1000
+                            "maxLength": 63
                         }
                     }
                 ],
@@ -301,7 +301,7 @@
                                             "type": "string",
                                             "description": "Unique identifier name for the zone",
                                             "minLength": 1,
-                                            "maxLength": 1000
+                                            "maxLength": 63
                                         },
                                         "Management_Master": {
                                             "type": "object",
@@ -2140,7 +2140,7 @@
                 "type": "string",
                 "description": "Unique identifier name for the zone",
                 "minLength": 1,
-                "maxLength": 1000
+                "maxLength": 63
             },
             "ZonesResponse": {
                 "type": "object",
@@ -2163,7 +2163,7 @@
                                     "type": "string",
                                     "description": "Unique identifier name for the zone",
                                     "minLength": 1,
-                                    "maxLength": 1000
+                                    "maxLength": 63
                                 },
                                 "Kubernetes_Topology_Zone": {
                                     "type": "object",
@@ -2217,7 +2217,7 @@
                         "type": "string",
                         "description": "Unique identifier name for the zone",
                         "minLength": 1,
-                        "maxLength": 1000
+                        "maxLength": 63
                     },
                     "Kubernetes_Topology_Zone": {
                         "type": "object",
@@ -2304,7 +2304,7 @@
                         "type": "string",
                         "description": "Unique identifier name for the zone",
                         "minLength": 1,
-                        "maxLength": 1000
+                        "maxLength": 63
                     },
                     "Management_Master": {
                         "type": "object",


### PR DESCRIPTION
## Summary and Scope

Fixing the length of the name. Since the zone name is a label, as per Kubernetes standards, the name should be 1-63.


## Issues and Related PRs

* Resolves [CASM-5675](https://jira-pro.it.hpe.com:8443/browse/CASM-5675)


## Testing

Tested on:

  * odin

Test description:
- Ran `cray rrs zones describe zone-name` command



## Risks and Mitigations

None


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
